### PR TITLE
fix: fixed typo in sdk exported type IMicrofrontendIntegrator

### DIFF
--- a/packages/console-sdk-microfrontend/CHANGELOG.md
+++ b/packages/console-sdk-microfrontend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mia-platform/console-sdk-microfrontend
 
+## Unreleased
+
+### Fixed
+
+- Fixed typo in exported type `IMicrofrontendIntegrator`
+
 ## 0.0.35
 
 ### Patch Changes

--- a/packages/console-sdk-microfrontend/CHANGELOG.md
+++ b/packages/console-sdk-microfrontend/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed typo in exported type `IMicrofrontendIntegrator`
+- **BREAKING**: fixed typo in exported type `IMicrofrontendIntegrator`
 
 ## 0.0.35
 

--- a/packages/console-sdk-microfrontend/src/MicrofrontendIntegrator.ts
+++ b/packages/console-sdk-microfrontend/src/MicrofrontendIntegrator.ts
@@ -21,14 +21,14 @@ import { Subject } from 'rxjs'
 import { ContextsType, Events, IConsoleProps, IContexts, ISDKConsoleObservable } from './types'
 import { getConsoleProps } from './adaptConsoleProps'
 
-export type IMicrofronendIntegrator = {
+export type IMicrofrontendIntegrator = {
   getContext(contextType: ContextsType): IContexts[keyof IContexts] | undefined
   getContainerId(): string
   getMicrofrontendNode(): HTMLElement
   getConsoleConfigObservable(): ISDKConsoleObservable
   sendEvent(event: Events): void
 }
-export default class MicrofronendIntegrator implements IMicrofronendIntegrator {
+export default class MicrofrontendIntegrator implements IMicrofrontendIntegrator {
   private events: Subject<Events>
 
   private name: string

--- a/packages/console-sdk-microfrontend/src/index.ts
+++ b/packages/console-sdk-microfrontend/src/index.ts
@@ -16,13 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import ConsoleSDK, { IMicrofronendIntegrator } from './MicrofrontendIntegrator'
+import ConsoleSDK, { IMicrofrontendIntegrator } from './MicrofrontendIntegrator'
 import { Events, EventsTypes, IConsoleProps, ISDKProps } from './types'
 
 export type {
   ISDKProps,
   IConsoleProps,
-  IMicrofronendIntegrator,
+  IMicrofrontendIntegrator,
   Events,
   EventsTypes,
 }

--- a/packages/console-sdk-vite-helpers/src/renderViteMicroApp.ts
+++ b/packages/console-sdk-vite-helpers/src/renderViteMicroApp.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ConsoleSDK, IConsoleProps, IMicrofronendIntegrator } from '@mia-platform/console-sdk-microfrontend'
+import { ConsoleSDK, IConsoleProps, IMicrofrontendIntegrator } from '@mia-platform/console-sdk-microfrontend'
 import { QiankunProps, qiankunWindow, renderWithQiankun } from 'vite-plugin-qiankun/dist/helper'
 
 export type ConsoleLifecycleFunction = (
   isConnectedToConsole: boolean,
-  consoleSDK: IMicrofronendIntegrator,
+  consoleSDK: IMicrofrontendIntegrator,
 ) => void
 
 export type IViteParams = {
@@ -32,7 +32,7 @@ export type IViteParams = {
 }
 
 export function getSDK(props: QiankunProps): {
-  consoleSDK: IMicrofronendIntegrator
+  consoleSDK: IMicrofrontendIntegrator
   isConnectedToConsole: boolean
 } {
   const consoleSDK = new ConsoleSDK(props as IConsoleProps)

--- a/packages/console-sdk-webpack-helpers/src/renderWebpackMicroApp.ts
+++ b/packages/console-sdk-webpack-helpers/src/renderWebpackMicroApp.ts
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ConsoleSDK, IConsoleProps, IMicrofronendIntegrator } from '@mia-platform/console-sdk-microfrontend'
+import { ConsoleSDK, IConsoleProps, IMicrofrontendIntegrator } from '@mia-platform/console-sdk-microfrontend'
 import { QiankunLifeCycle, QiankunProps, qiankunWindow } from 'vite-plugin-qiankun/dist/helper'
 
 export type ConsoleLifecycleFunction = (
   isConnectedToConsole: boolean,
-  consoleSDK: IMicrofronendIntegrator,
+  consoleSDK: IMicrofrontendIntegrator,
 ) => void
 
 export type IViteParams = {
@@ -32,7 +32,7 @@ export type IViteParams = {
 }
 
 export function getSDK(props: IConsoleProps): {
-  consoleSDK: IMicrofronendIntegrator
+  consoleSDK: IMicrofrontendIntegrator
   isConnectedToConsole: boolean
 } {
   const consoleSDK = new ConsoleSDK(props)


### PR DESCRIPTION
The goal of this PR is to fix a typo in the type `IMicrofrontendIntegrator` exported by the SDK (previously was `IMicrofronendIntegrator`.

Be aware that, since the type was exported, this change technically qualifies as a breaking change.