### PR TITLE
feat: add MongoDB view default routes

### DIFF
--- a/.changeset/chilled-tomatoes-sip.md
+++ b/.changeset/chilled-tomatoes-sip.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+fix: added MongoDB View default routes

--- a/packages/console-types/CHANGELOG.md
+++ b/packages/console-types/CHANGELOG.md
@@ -1,11 +1,5 @@
 # CHANGELOG
 
-## Unreleased
-
-### Fixed
-
-- [DTFBRC-469](https://makeitapp.atlassian.net/browse/DTFBRC-469): added MongoDB View default routes
-
 ## 0.19.21
 
 ### Patch Changes

--- a/packages/console-types/CHANGELOG.md
+++ b/packages/console-types/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- [DTFBRC-469](https://makeitapp.atlassian.net/browse/DTFBRC-469): added MongoDB View default routes
+
 ## 0.19.21
 
 ### Patch Changes

--- a/packages/console-types/CHANGELOG.md
+++ b/packages/console-types/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Fixed
+
 - [DTFBRC-469](https://makeitapp.atlassian.net/browse/DTFBRC-469): added MongoDB View default routes
 
 ## 0.19.21

--- a/packages/console-types/src/constants/endpoints.ts
+++ b/packages/console-types/src/constants/endpoints.ts
@@ -88,6 +88,36 @@ export type CrudRoute = {
   allowUnknownResponseContentType?: boolean
 }
 
+export const MONGODB_VIEW_ROUTES: CrudRoute[] = [{
+  path: '/',
+  verb: METHOD_GET,
+}, {
+  path: '/',
+  verb: 'POST',
+}, {
+  path: '/export',
+  verb: METHOD_GET,
+  allowUnknownResponseContentType: true,
+}, {
+  path: '/:id',
+  verb: METHOD_GET,
+}, {
+  path: '/:id',
+  verb: 'DELETE',
+}, {
+  path: '/:id',
+  verb: 'PATCH',
+}, {
+  path: '/count',
+  verb: METHOD_GET,
+}, {
+  path: '/lookup/:id',
+  verb: METHOD_GET,
+}, {
+  path: '/schema',
+  verb: METHOD_GET,
+}]
+
 export const CRUD_ROUTES: CrudRoute[] = [{
   path: '/',
   verb: METHOD_GET,


### PR DESCRIPTION
This PR has the goal of adding default routes for MongoDB views. Therefore, a constant has been added to console types for endpoints.