### PR TITLE
refactor(types): extend exposed routes for views with lookup enabled

### DIFF
--- a/.changeset/nervous-hats-hug.md
+++ b/.changeset/nervous-hats-hug.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+add missing endpoint routes for CRUD Service Views with enabled lookup feature

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,9 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9
           run_install: false
       - name: Build Monorepo and Publish
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
     - uses: pnpm/action-setup@v4
       name: Install pnpm
       with:
-        version: 9
         run_install: false
     - name: Install Packages
       run: pnpm i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - uses: pnpm/action-setup@v3
+    - uses: pnpm/action-setup@v4
       name: Install pnpm
       with:
-        version: 8
+        version: 9
         run_install: false
     - name: Install Packages
       run: pnpm i

--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
     "Daniele Cinà <daniele.cina@mia-platform.eu>",
     "Davide Bianchi <davide.bianchi@mia-platform.eu>",
     "Federico Maggi <federico.maggi@mia-platform.eu>"
-  ]
+  ],
+  "packageManager": "pnpm@9.7.1+sha256.46f1bbc8f8020aa9869568c387198f1a813f21fb44c82f400e7d1dbde6c70b40"
 }

--- a/packages/console-types/CHANGELOG.md
+++ b/packages/console-types/CHANGELOG.md
@@ -1,10 +1,5 @@
 # CHANGELOG
 
-- refactor: extend which endpoints routes are displayed when creating endpoints for CRUD Service Views with lookup feature enabled
-- update `pnpm` to v9
-- remove testing for node 16
-- add testing for node 22
-
 ## 0.21.0
 
 ### Minor Changes

--- a/packages/console-types/CHANGELOG.md
+++ b/packages/console-types/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+- refactor: extend which endpoints routes are displayed when creating endpoints for CRUD Service Views with lookup feature enabled
+- update `pnpm` to v9
+- remove testing for node 16
+- add testing for node 22
+
 ## 0.21.0
 
 ### Minor Changes

--- a/packages/console-types/src/constants/endpoints.ts
+++ b/packages/console-types/src/constants/endpoints.ts
@@ -88,35 +88,77 @@ export type CrudRoute = {
   allowUnknownResponseContentType?: boolean
 }
 
-export const MONGODB_VIEW_ROUTES: CrudRoute[] = [{
-  path: '/',
-  verb: METHOD_GET,
-}, {
-  path: '/',
-  verb: 'POST',
-}, {
-  path: '/export',
-  verb: METHOD_GET,
-  allowUnknownResponseContentType: true,
-}, {
-  path: '/:id',
-  verb: METHOD_GET,
-}, {
-  path: '/:id',
-  verb: 'DELETE',
-}, {
-  path: '/:id',
-  verb: 'PATCH',
-}, {
-  path: '/count',
-  verb: METHOD_GET,
-}, {
-  path: '/lookup/:id',
-  verb: METHOD_GET,
-}, {
-  path: '/schema',
-  verb: METHOD_GET,
-}]
+export const MONGODB_VIEW_ROUTES: CrudRoute[] = [
+  {
+    path: '/',
+    verb: METHOD_GET,
+  },
+  {
+    path: '/',
+    verb: 'POST',
+  },
+  {
+    path: '/export',
+    verb: METHOD_GET,
+    allowUnknownResponseContentType: true,
+  },
+  {
+    path: '/:id',
+    verb: METHOD_GET,
+  },
+  {
+    path: '/:id',
+    verb: 'DELETE',
+  },
+  {
+    path: '/:id',
+    verb: 'PATCH',
+  },
+  {
+    path: '/count',
+    verb: METHOD_GET,
+  },
+  {
+    path: '/lookup/:id',
+    verb: METHOD_GET,
+  },
+  {
+    path: '/schema',
+    verb: METHOD_GET,
+  },
+  {
+    path: '/',
+    verb: 'DELETE',
+  },
+  {
+    path: '/',
+    verb: 'PATCH',
+  },
+  {
+    path: '/count',
+    verb: METHOD_GET,
+  },
+  {
+    path: '/bulk',
+    verb: 'POST',
+  },
+  {
+    path: '/upsert-one',
+    verb: 'POST',
+  },
+  {
+    path: '/bulk',
+    verb: 'PATCH',
+  },
+  {
+    path: '/:id/state',
+    verb: 'POST',
+  },
+  {
+    path: '/state',
+    verb: 'POST',
+  },
+]
 
 export const CRUD_ROUTES: CrudRoute[] = [{
   path: '/',


### PR DESCRIPTION
Hi, with this PR I would like to extend which routes are available in the endpoints section for [CRUD Service Views with enabled lookup feature](https://docs.mia-platform.eu/docs/runtime_suite/crud-service/writable_views).  
In this manner that all the endpoints CRUD Service exposes can be employed by other systems (e.g for example the Microfrontend Composer) to provide their own functionalities.

**Note:** in order to have the CI working I needed to update also the `pnpm` version (to v9) and the `node` version (drop testing v16 and added v22).