### PR TITLE
fix(types): max length to k8s resource names

### DIFF
--- a/packages/console-types/src/strings/en.json
+++ b/packages/console-types/src/strings/en.json
@@ -1,7 +1,7 @@
 {
   "endpoint.basePath.patternError": "Must start with \"/\" and can contain alphanumeric characters and the symbols \"_\", \"-\", and \".\", optionally preceded by \":\"",
   "configMountPath.patternError": "Can contain alphanumeric characters, parentheses, spaces and the symbols - , _ , . , | , \\ ,  / , ! , \" , £, $ , % , & , = , ? , ^ ,* , +, @",
-  "resourceName.patternError": "Must start with a lowercase character and can contain lowercase letters, numbers and the symbol \"-\". Cannot end with \"-\". Cannot exceed 253 characters in length.",
+  "resourceName.patternError": "Must start with a lowercase character and can contain lowercase letters, numbers and the symbol \"-\". Cannot end with \"-\". Cannot exceed 253 characters in length",
   "dockerImage.patternError": "Must respect the format host/imagename:tag, where host and tag are optional. Image name and tag can be interpolated",
   "configMapFileName.patternError": "Can contain alphanumeric characters and the symbols \"_\", \"-\" and \".\"",
   "swaggerPath.patternError": "Must start with \"/\". Can contain alphanumeric characters and the symbols \"_\", \"-\" and \".\"",

--- a/packages/console-types/src/strings/en.json
+++ b/packages/console-types/src/strings/en.json
@@ -1,7 +1,7 @@
 {
   "endpoint.basePath.patternError": "Must start with \"/\" and can contain alphanumeric characters and the symbols \"_\", \"-\", and \".\", optionally preceded by \":\"",
   "configMountPath.patternError": "Can contain alphanumeric characters, parentheses, spaces and the symbols - , _ , . , | , \\ ,  / , ! , \" , £, $ , % , & , = , ? , ^ ,* , +, @",
-  "resourceName.patternError": "Must start with a lowercase character and can contain lowercase letters, numbers and the symbol \"-\". Cannot end with \"-\"",
+  "resourceName.patternError": "Must start with a lowercase character and can contain lowercase letters, numbers and the symbol \"-\". Cannot end with \"-\". Cannot exceed 253 characters in length.",
   "dockerImage.patternError": "Must respect the format host/imagename:tag, where host and tag are optional. Image name and tag can be interpolated",
   "configMapFileName.patternError": "Can contain alphanumeric characters and the symbols \"_\", \"-\" and \".\"",
   "swaggerPath.patternError": "Must start with \"/\". Can contain alphanumeric characters and the symbols \"_\", \"-\" and \".\"",

--- a/packages/console-types/src/strings/it.json
+++ b/packages/console-types/src/strings/it.json
@@ -1,7 +1,7 @@
 {
   "endpoint.basePath.patternError": "Deve iniziare con \"/\" e può contenere caratteri alfanumerici e i simboli \"_\", \"-\" e \".\", eventualmente preceduti da \":\"",
   "configMountPath.patternError": "Può contenere caratteri alfanumerici, parentesi, spazi e i simboli - , _ , . , | , \\ ,  / , ! , \" , £, $ , % , & , = , ? , ^ ,* , +, @",
-  "resourceName.patternError": "Deve iniziare con una lettera minuscola e può contenere lettere minuscole, numeri e il simbolo \"-\". Non può terminare con \"-\"",
+  "resourceName.patternError": "Deve iniziare con una lettera minuscola e può contenere lettere minuscole, numeri e il simbolo \"-\". Non può terminare con \"-\". Non può superare i 253 caratteri di lunghezza",
   "dockerImage.patternError": "Deve rispettare il formato host/imagename:tag, con host e tag opzionali. I valori di imagename e tag possono essere interpolati",
   "configMapFileName.patternError": "Può contenere caratteri alfanumerici e i simboli \"_\", \"-\" e \".\"",
   "swaggerPath.patternError": "Deve iniziare con \"/\". Può contenere caratteri alfanumerici e i simboli \"_\", \"-\" e \".\"",

--- a/packages/console-types/src/types/services.ts
+++ b/packages/console-types/src/types/services.ts
@@ -30,6 +30,7 @@ import { ownersSchema } from './collections'
 export const serviceName = {
   type: 'string',
   minLength: 1,
+  maxLength: 253,
   pattern: '^[a-z]([-a-z0-9]*[a-z0-9])?$',
   [VALIDATION_ERROR_ID]: 'resourceName.patternError',
 } as const
@@ -63,6 +64,8 @@ export const swaggerPath = {
 
 export const serviceSecretName = {
   type: 'string',
+  minLength: 1,
+  maxLength: 253,
   pattern: '^[a-z][a-z0-9]*(-[a-z0-9]+)*$',
   [VALIDATION_ERROR_ID]: 'resourceName.patternError',
 } as const
@@ -75,6 +78,8 @@ export const serviceSecretKey = {
 
 export const configMapName = {
   type: 'string',
+  minLength: 1,
+  maxLength: 253,
   pattern: '^[a-z][a-z0-9]*(-[a-z0-9]+)*$',
   [VALIDATION_ERROR_ID]: 'resourceName.patternError',
 } as const


### PR DESCRIPTION
As per DNS subdomain specification, all Kubernetes names must have a length equal or lower than 253 chars