### PR TITLE
feat(IDP-2316): expose proxy information in GET extension APIs

### DIFF
--- a/.changeset/tiny-baboons-rest.md
+++ b/.changeset/tiny-baboons-rest.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-client": patch
+---
+
+expose proxy information in GET extension APIs

--- a/packages/console-client/oas-schema/console-apis-schema.json
+++ b/packages/console-client/oas-schema/console-apis-schema.json
@@ -142,6 +142,13 @@
                 "parameters": [
                     {
                         "in": "query",
+                        "name": "environmentId",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
                         "name": "projectId",
                         "schema": {
                             "type": "string"
@@ -163,12 +170,11 @@
                                     "items": {
                                         "additionalProperties": false,
                                         "properties": {
+                                            "configuration": {
+                                                "type": "object"
+                                            },
                                             "entry": {
                                                 "type": "string"
-                                            },
-                                            "configuration": {
-                                                "type": "object",
-                                                "additionalProperties": true
                                             },
                                             "microfrontendId": {
                                                 "type": "string"
@@ -233,6 +239,9 @@
                                                     "type": "object"
                                                 },
                                                 "type": "array"
+                                            },
+                                            "serverSideResolvedRoutes": {
+                                                "type": "boolean"
                                             },
                                             "type": {
                                                 "type": "string"
@@ -435,12 +444,18 @@
                                                             "type": "string"
                                                         },
                                                         "type": "object"
+                                                    },
+                                                    "order": {
+                                                        "type": "number"
                                                     }
                                                 },
                                                 "required": [
                                                     "id"
                                                 ],
                                                 "type": "object"
+                                            },
+                                            "configuration": {
+                                                "type": "string"
                                             },
                                             "description": {
                                                 "type": "string"
@@ -450,17 +465,18 @@
                                                 "properties": {
                                                     "id": {
                                                         "type": "string"
+                                                    },
+                                                    "path": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
-                                                    "id"
+                                                    "id",
+                                                    "path"
                                                 ],
                                                 "type": "object"
                                             },
                                             "entry": {
-                                                "type": "string"
-                                            },
-                                            "configuration": {
                                                 "type": "string"
                                             },
                                             "extensionId": {
@@ -495,6 +511,49 @@
                                                 "type": "string"
                                             },
                                             "permissions": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            "proxy": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "authType": {
+                                                        "type": "string"
+                                                    },
+                                                    "authentication": {
+                                                        "type": "string"
+                                                    },
+                                                    "basePath": {
+                                                        "type": "string"
+                                                    },
+                                                    "clientId": {
+                                                        "type": "string"
+                                                    },
+                                                    "grantType": {
+                                                        "type": "string"
+                                                    },
+                                                    "headersToProxy": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    "targetBaseUrl": {
+                                                        "type": "string"
+                                                    },
+                                                    "username": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "basePath",
+                                                    "targetBaseUrl"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "roleIds": {
                                                 "items": {
                                                     "type": "string"
                                                 },
@@ -613,6 +672,9 @@
                                         ],
                                         "type": "object"
                                     },
+                                    "configuration": {
+                                        "type": "string"
+                                    },
                                     "description": {
                                         "type": "string"
                                     },
@@ -633,9 +695,6 @@
                                         "type": "object"
                                     },
                                     "entry": {
-                                        "type": "string"
-                                    },
-                                    "configuration": {
                                         "type": "string"
                                     },
                                     "extensionId": {
@@ -670,6 +729,12 @@
                                         "type": "string"
                                     },
                                     "permissions": {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    "roleIds": {
                                         "items": {
                                             "type": "string"
                                         },
@@ -843,6 +908,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "`true`: include visibilities and proxies in the response. `false` only extension data is returned. default value is `false`.",
+                        "in": "query",
+                        "name": "resolveDetails",
+                        "schema": {
+                            "type": "boolean"
+                        }
                     }
                 ],
                 "responses": {
@@ -869,12 +942,18 @@
                                                         "type": "string"
                                                     },
                                                     "type": "object"
+                                                },
+                                                "order": {
+                                                    "type": "number"
                                                 }
                                             },
                                             "required": [
                                                 "id"
                                             ],
                                             "type": "object"
+                                        },
+                                        "configuration": {
+                                            "type": "string"
                                         },
                                         "description": {
                                             "type": "string"
@@ -884,17 +963,18 @@
                                             "properties": {
                                                 "id": {
                                                     "type": "string"
+                                                },
+                                                "path": {
+                                                    "type": "string"
                                                 }
                                             },
                                             "required": [
-                                                "id"
+                                                "id",
+                                                "path"
                                             ],
                                             "type": "object"
                                         },
                                         "entry": {
-                                            "type": "string"
-                                        },
-                                        "configuration": {
                                             "type": "string"
                                         },
                                         "extensionId": {
@@ -929,6 +1009,49 @@
                                             "type": "string"
                                         },
                                         "permissions": {
+                                            "items": {
+                                                "type": "string"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "proxy": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "authType": {
+                                                    "type": "string"
+                                                },
+                                                "authentication": {
+                                                    "type": "string"
+                                                },
+                                                "basePath": {
+                                                    "type": "string"
+                                                },
+                                                "clientId": {
+                                                    "type": "string"
+                                                },
+                                                "grantType": {
+                                                    "type": "string"
+                                                },
+                                                "headersToProxy": {
+                                                    "items": {
+                                                        "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                },
+                                                "targetBaseUrl": {
+                                                    "type": "string"
+                                                },
+                                                "username": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "required": [
+                                                "basePath",
+                                                "targetBaseUrl"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "roleIds": {
                                             "items": {
                                                 "type": "string"
                                             },
@@ -1102,7 +1225,7 @@
                                 }
                             }
                         },
-                        "description": "Returns registered extension id"
+                        "description": "Returns activated extension id"
                     },
                     "400": {
                         "content": {

--- a/packages/console-client/src/kiota-client/api/extensibility/extensions/index.ts
+++ b/packages/console-client/src/kiota-client/api/extensibility/extensions/index.ts
@@ -78,6 +78,7 @@ export function deserializeIntoExtensions(extensions: Partial<Extensions> | unde
         "entry": n => { extensions.entry = n.getStringValue(); },
         "microfrontendId": n => { extensions.microfrontendId = n.getStringValue(); },
         "routes": n => { extensions.routes = n.getCollectionOfObjectValues<Extensions_routes>(createExtensions_routesFromDiscriminatorValue); },
+        "serverSideResolvedRoutes": n => { extensions.serverSideResolvedRoutes = n.getBooleanValue(); },
         "type": n => { extensions.type = n.getStringValue(); },
     }
 }
@@ -168,6 +169,10 @@ export interface Extensions extends Parsable {
      * The routes property
      */
     routes?: Extensions_routes[] | null;
+    /**
+     * The serverSideResolvedRoutes property
+     */
+    serverSideResolvedRoutes?: boolean | null;
     /**
      * The type property
      */
@@ -285,6 +290,7 @@ export interface ExtensionsRequestBuilder extends BaseRequestBuilder<ExtensionsR
      toGetRequestInformation(requestConfiguration?: RequestConfiguration<ExtensionsRequestBuilderGetQueryParameters> | undefined) : RequestInformation;
 }
 export interface ExtensionsRequestBuilderGetQueryParameters {
+    environmentId?: string;
     projectId?: string;
     tenantId?: string;
 }
@@ -299,6 +305,7 @@ export function serializeExtensions(writer: SerializationWriter, extensions: Par
         writer.writeStringValue("entry", extensions.entry);
         writer.writeStringValue("microfrontendId", extensions.microfrontendId);
         writer.writeCollectionOfObjectValues<Extensions_routes>("routes", extensions.routes, serializeExtensions_routes);
+        writer.writeBooleanValue("serverSideResolvedRoutes", extensions.serverSideResolvedRoutes);
         writer.writeStringValue("type", extensions.type);
     }
 }
@@ -379,7 +386,7 @@ export function serializeExtensions500Error(writer: SerializationWriter, extensi
 /**
  * Uri template for the request builder.
  */
-export const ExtensionsRequestBuilderUriTemplate = "{+baseurl}/api/extensibility/extensions{?projectId*,tenantId*}";
+export const ExtensionsRequestBuilderUriTemplate = "{+baseurl}/api/extensibility/extensions{?environmentId*,projectId*,tenantId*}";
 export const Extensions_routes_locationIdObject = {
     Tenant: "tenant",
     Project: "project",

--- a/packages/console-client/src/kiota-client/api/extensibility/tenants/item/extensions/index.ts
+++ b/packages/console-client/src/kiota-client/api/extensibility/tenants/item/extensions/index.ts
@@ -54,6 +54,15 @@ export function createExtensions_menuFromDiscriminatorValue(parseNode: ParseNode
 /**
  * Creates a new instance of the appropriate class based on discriminator value
  * @param parseNode The parse node to use to read the discriminator value and create the object
+ * @returns {Extensions_proxy}
+ */
+// @ts-ignore
+export function createExtensions_proxyFromDiscriminatorValue(parseNode: ParseNode | undefined) : ((instance?: Parsable) => Record<string, (node: ParseNode) => void>) {
+    return deserializeIntoExtensions_proxy;
+}
+/**
+ * Creates a new instance of the appropriate class based on discriminator value
+ * @param parseNode The parse node to use to read the discriminator value and create the object
  * @returns {Extensions_visibilities}
  */
 // @ts-ignore
@@ -168,6 +177,8 @@ export function deserializeIntoExtensions(extensions: Partial<Extensions> | unde
         "menu": n => { extensions.menu = n.getObjectValue<Extensions_menu>(createExtensions_menuFromDiscriminatorValue); },
         "name": n => { extensions.name = n.getStringValue(); },
         "permissions": n => { extensions.permissions = n.getCollectionOfPrimitiveValues<string>(); },
+        "proxy": n => { extensions.proxy = n.getObjectValue<Extensions_proxy>(createExtensions_proxyFromDiscriminatorValue); },
+        "roleIds": n => { extensions.roleIds = n.getCollectionOfPrimitiveValues<string>(); },
         "type": n => { extensions.type = n.getStringValue(); },
         "visibilities": n => { extensions.visibilities = n.getCollectionOfObjectValues<Extensions_visibilities>(createExtensions_visibilitiesFromDiscriminatorValue); },
     }
@@ -181,6 +192,7 @@ export function deserializeIntoExtensions_category(extensions_category: Partial<
     return {
         "id": n => { extensions_category.id = n.getStringValue(); },
         "labelIntl": n => { extensions_category.labelIntl = n.getObjectValue<Extensions_category_labelIntl>(createExtensions_category_labelIntlFromDiscriminatorValue); },
+        "order": n => { extensions_category.order = n.getNumberValue(); },
     }
 }
 /**
@@ -200,6 +212,7 @@ export function deserializeIntoExtensions_category_labelIntl(extensions_category
 export function deserializeIntoExtensions_destination(extensions_destination: Partial<Extensions_destination> | undefined = {}) : Record<string, (node: ParseNode) => void> {
     return {
         "id": n => { extensions_destination.id = n.getStringValue(); },
+        "path": n => { extensions_destination.path = n.getStringValue(); },
     }
 }
 /**
@@ -221,6 +234,23 @@ export function deserializeIntoExtensions_menu(extensions_menu: Partial<Extensio
 // @ts-ignore
 export function deserializeIntoExtensions_menu_labelIntl(extensions_menu_labelIntl: Partial<Extensions_menu_labelIntl> | undefined = {}) : Record<string, (node: ParseNode) => void> {
     return {
+    }
+}
+/**
+ * The deserialization information for the current model
+ * @returns {Record<string, (node: ParseNode) => void>}
+ */
+// @ts-ignore
+export function deserializeIntoExtensions_proxy(extensions_proxy: Partial<Extensions_proxy> | undefined = {}) : Record<string, (node: ParseNode) => void> {
+    return {
+        "authentication": n => { extensions_proxy.authentication = n.getStringValue(); },
+        "authType": n => { extensions_proxy.authType = n.getStringValue(); },
+        "basePath": n => { extensions_proxy.basePath = n.getStringValue(); },
+        "clientId": n => { extensions_proxy.clientId = n.getStringValue(); },
+        "grantType": n => { extensions_proxy.grantType = n.getStringValue(); },
+        "headersToProxy": n => { extensions_proxy.headersToProxy = n.getCollectionOfPrimitiveValues<string>(); },
+        "targetBaseUrl": n => { extensions_proxy.targetBaseUrl = n.getStringValue(); },
+        "username": n => { extensions_proxy.username = n.getStringValue(); },
     }
 }
 /**
@@ -276,6 +306,7 @@ export function deserializeIntoExtensionsPutRequestBody(extensionsPutRequestBody
         "menu": n => { extensionsPutRequestBody.menu = n.getObjectValue<ExtensionsPutRequestBody_menu>(createExtensionsPutRequestBody_menuFromDiscriminatorValue); },
         "name": n => { extensionsPutRequestBody.name = n.getStringValue(); },
         "permissions": n => { extensionsPutRequestBody.permissions = n.getCollectionOfPrimitiveValues<string>(); },
+        "roleIds": n => { extensionsPutRequestBody.roleIds = n.getCollectionOfPrimitiveValues<string>(); },
         "type": n => { extensionsPutRequestBody.type = n.getStringValue(); },
     }
 }
@@ -388,6 +419,14 @@ export interface Extensions extends Parsable {
      */
     permissions?: string[] | null;
     /**
+     * The proxy property
+     */
+    proxy?: Extensions_proxy | null;
+    /**
+     * The roleIds property
+     */
+    roleIds?: string[] | null;
+    /**
      * The type property
      */
     type?: string | null;
@@ -405,6 +444,10 @@ export interface Extensions_category extends Parsable {
      * The labelIntl property
      */
     labelIntl?: Extensions_category_labelIntl | null;
+    /**
+     * The order property
+     */
+    order?: number | null;
 }
 export interface Extensions_category_labelIntl extends AdditionalDataHolder, Parsable {
     /**
@@ -417,6 +460,10 @@ export interface Extensions_destination extends Parsable {
      * The id property
      */
     id?: string | null;
+    /**
+     * The path property
+     */
+    path?: string | null;
 }
 export interface Extensions_menu extends Parsable {
     /**
@@ -437,6 +484,40 @@ export interface Extensions_menu_labelIntl extends AdditionalDataHolder, Parsabl
      * Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
      */
     additionalData?: Record<string, unknown>;
+}
+export interface Extensions_proxy extends Parsable {
+    /**
+     * The authentication property
+     */
+    authentication?: string | null;
+    /**
+     * The authType property
+     */
+    authType?: string | null;
+    /**
+     * The basePath property
+     */
+    basePath?: string | null;
+    /**
+     * The clientId property
+     */
+    clientId?: string | null;
+    /**
+     * The grantType property
+     */
+    grantType?: string | null;
+    /**
+     * The headersToProxy property
+     */
+    headersToProxy?: string[] | null;
+    /**
+     * The targetBaseUrl property
+     */
+    targetBaseUrl?: string | null;
+    /**
+     * The username property
+     */
+    username?: string | null;
 }
 export interface Extensions_visibilities extends Parsable {
     /**
@@ -529,6 +610,10 @@ export interface ExtensionsPutRequestBody extends Parsable {
      * The permissions property
      */
     permissions?: string[] | null;
+    /**
+     * The roleIds property
+     */
+    roleIds?: string[] | null;
     /**
      * The type property
      */
@@ -647,6 +732,8 @@ export function serializeExtensions(writer: SerializationWriter, extensions: Par
         writer.writeObjectValue<Extensions_menu>("menu", extensions.menu, serializeExtensions_menu);
         writer.writeStringValue("name", extensions.name);
         writer.writeCollectionOfPrimitiveValues<string>("permissions", extensions.permissions);
+        writer.writeObjectValue<Extensions_proxy>("proxy", extensions.proxy, serializeExtensions_proxy);
+        writer.writeCollectionOfPrimitiveValues<string>("roleIds", extensions.roleIds);
         writer.writeStringValue("type", extensions.type);
         writer.writeCollectionOfObjectValues<Extensions_visibilities>("visibilities", extensions.visibilities, serializeExtensions_visibilities);
     }
@@ -660,6 +747,7 @@ export function serializeExtensions_category(writer: SerializationWriter, extens
     if (extensions_category) {
         writer.writeStringValue("id", extensions_category.id);
         writer.writeObjectValue<Extensions_category_labelIntl>("labelIntl", extensions_category.labelIntl, serializeExtensions_category_labelIntl);
+        writer.writeNumberValue("order", extensions_category.order);
     }
 }
 /**
@@ -680,6 +768,7 @@ export function serializeExtensions_category_labelIntl(writer: SerializationWrit
 export function serializeExtensions_destination(writer: SerializationWriter, extensions_destination: Partial<Extensions_destination> | undefined | null = {}) : void {
     if (extensions_destination) {
         writer.writeStringValue("id", extensions_destination.id);
+        writer.writeStringValue("path", extensions_destination.path);
     }
 }
 /**
@@ -702,6 +791,23 @@ export function serializeExtensions_menu(writer: SerializationWriter, extensions
 export function serializeExtensions_menu_labelIntl(writer: SerializationWriter, extensions_menu_labelIntl: Partial<Extensions_menu_labelIntl> | undefined | null = {}) : void {
     if (extensions_menu_labelIntl) {
         writer.writeAdditionalData(extensions_menu_labelIntl.additionalData);
+    }
+}
+/**
+ * Serializes information the current object
+ * @param writer Serialization writer to use to serialize this model
+ */
+// @ts-ignore
+export function serializeExtensions_proxy(writer: SerializationWriter, extensions_proxy: Partial<Extensions_proxy> | undefined | null = {}) : void {
+    if (extensions_proxy) {
+        writer.writeStringValue("authentication", extensions_proxy.authentication);
+        writer.writeStringValue("authType", extensions_proxy.authType);
+        writer.writeStringValue("basePath", extensions_proxy.basePath);
+        writer.writeStringValue("clientId", extensions_proxy.clientId);
+        writer.writeStringValue("grantType", extensions_proxy.grantType);
+        writer.writeCollectionOfPrimitiveValues<string>("headersToProxy", extensions_proxy.headersToProxy);
+        writer.writeStringValue("targetBaseUrl", extensions_proxy.targetBaseUrl);
+        writer.writeStringValue("username", extensions_proxy.username);
     }
 }
 /**
@@ -759,6 +865,7 @@ export function serializeExtensionsPutRequestBody(writer: SerializationWriter, e
         writer.writeObjectValue<ExtensionsPutRequestBody_menu>("menu", extensionsPutRequestBody.menu, serializeExtensionsPutRequestBody_menu);
         writer.writeStringValue("name", extensionsPutRequestBody.name);
         writer.writeCollectionOfPrimitiveValues<string>("permissions", extensionsPutRequestBody.permissions);
+        writer.writeCollectionOfPrimitiveValues<string>("roleIds", extensionsPutRequestBody.roleIds);
         writer.writeStringValue("type", extensionsPutRequestBody.type);
     }
 }

--- a/packages/console-client/src/kiota-client/api/extensibility/tenants/item/extensions/item/index.ts
+++ b/packages/console-client/src/kiota-client/api/extensibility/tenants/item/extensions/item/index.ts
@@ -65,6 +65,15 @@ export function createWithExtensionGetResponse_menuFromDiscriminatorValue(parseN
 /**
  * Creates a new instance of the appropriate class based on discriminator value
  * @param parseNode The parse node to use to read the discriminator value and create the object
+ * @returns {WithExtensionGetResponse_proxy}
+ */
+// @ts-ignore
+export function createWithExtensionGetResponse_proxyFromDiscriminatorValue(parseNode: ParseNode | undefined) : ((instance?: Parsable) => Record<string, (node: ParseNode) => void>) {
+    return deserializeIntoWithExtensionGetResponse_proxy;
+}
+/**
+ * Creates a new instance of the appropriate class based on discriminator value
+ * @param parseNode The parse node to use to read the discriminator value and create the object
  * @returns {WithExtensionGetResponse_visibilities}
  */
 // @ts-ignore
@@ -110,6 +119,8 @@ export function deserializeIntoWithExtensionGetResponse(withExtensionGetResponse
         "menu": n => { withExtensionGetResponse.menu = n.getObjectValue<WithExtensionGetResponse_menu>(createWithExtensionGetResponse_menuFromDiscriminatorValue); },
         "name": n => { withExtensionGetResponse.name = n.getStringValue(); },
         "permissions": n => { withExtensionGetResponse.permissions = n.getCollectionOfPrimitiveValues<string>(); },
+        "proxy": n => { withExtensionGetResponse.proxy = n.getObjectValue<WithExtensionGetResponse_proxy>(createWithExtensionGetResponse_proxyFromDiscriminatorValue); },
+        "roleIds": n => { withExtensionGetResponse.roleIds = n.getCollectionOfPrimitiveValues<string>(); },
         "type": n => { withExtensionGetResponse.type = n.getStringValue(); },
         "visibilities": n => { withExtensionGetResponse.visibilities = n.getCollectionOfObjectValues<WithExtensionGetResponse_visibilities>(createWithExtensionGetResponse_visibilitiesFromDiscriminatorValue); },
     }
@@ -123,6 +134,7 @@ export function deserializeIntoWithExtensionGetResponse_category(withExtensionGe
     return {
         "id": n => { withExtensionGetResponse_category.id = n.getStringValue(); },
         "labelIntl": n => { withExtensionGetResponse_category.labelIntl = n.getObjectValue<WithExtensionGetResponse_category_labelIntl>(createWithExtensionGetResponse_category_labelIntlFromDiscriminatorValue); },
+        "order": n => { withExtensionGetResponse_category.order = n.getNumberValue(); },
     }
 }
 /**
@@ -142,6 +154,7 @@ export function deserializeIntoWithExtensionGetResponse_category_labelIntl(withE
 export function deserializeIntoWithExtensionGetResponse_destination(withExtensionGetResponse_destination: Partial<WithExtensionGetResponse_destination> | undefined = {}) : Record<string, (node: ParseNode) => void> {
     return {
         "id": n => { withExtensionGetResponse_destination.id = n.getStringValue(); },
+        "path": n => { withExtensionGetResponse_destination.path = n.getStringValue(); },
     }
 }
 /**
@@ -163,6 +176,23 @@ export function deserializeIntoWithExtensionGetResponse_menu(withExtensionGetRes
 // @ts-ignore
 export function deserializeIntoWithExtensionGetResponse_menu_labelIntl(withExtensionGetResponse_menu_labelIntl: Partial<WithExtensionGetResponse_menu_labelIntl> | undefined = {}) : Record<string, (node: ParseNode) => void> {
     return {
+    }
+}
+/**
+ * The deserialization information for the current model
+ * @returns {Record<string, (node: ParseNode) => void>}
+ */
+// @ts-ignore
+export function deserializeIntoWithExtensionGetResponse_proxy(withExtensionGetResponse_proxy: Partial<WithExtensionGetResponse_proxy> | undefined = {}) : Record<string, (node: ParseNode) => void> {
+    return {
+        "authentication": n => { withExtensionGetResponse_proxy.authentication = n.getStringValue(); },
+        "authType": n => { withExtensionGetResponse_proxy.authType = n.getStringValue(); },
+        "basePath": n => { withExtensionGetResponse_proxy.basePath = n.getStringValue(); },
+        "clientId": n => { withExtensionGetResponse_proxy.clientId = n.getStringValue(); },
+        "grantType": n => { withExtensionGetResponse_proxy.grantType = n.getStringValue(); },
+        "headersToProxy": n => { withExtensionGetResponse_proxy.headersToProxy = n.getCollectionOfPrimitiveValues<string>(); },
+        "targetBaseUrl": n => { withExtensionGetResponse_proxy.targetBaseUrl = n.getStringValue(); },
+        "username": n => { withExtensionGetResponse_proxy.username = n.getStringValue(); },
     }
 }
 /**
@@ -207,6 +237,8 @@ export function serializeWithExtensionGetResponse(writer: SerializationWriter, w
         writer.writeObjectValue<WithExtensionGetResponse_menu>("menu", withExtensionGetResponse.menu, serializeWithExtensionGetResponse_menu);
         writer.writeStringValue("name", withExtensionGetResponse.name);
         writer.writeCollectionOfPrimitiveValues<string>("permissions", withExtensionGetResponse.permissions);
+        writer.writeObjectValue<WithExtensionGetResponse_proxy>("proxy", withExtensionGetResponse.proxy, serializeWithExtensionGetResponse_proxy);
+        writer.writeCollectionOfPrimitiveValues<string>("roleIds", withExtensionGetResponse.roleIds);
         writer.writeStringValue("type", withExtensionGetResponse.type);
         writer.writeCollectionOfObjectValues<WithExtensionGetResponse_visibilities>("visibilities", withExtensionGetResponse.visibilities, serializeWithExtensionGetResponse_visibilities);
     }
@@ -220,6 +252,7 @@ export function serializeWithExtensionGetResponse_category(writer: Serialization
     if (withExtensionGetResponse_category) {
         writer.writeStringValue("id", withExtensionGetResponse_category.id);
         writer.writeObjectValue<WithExtensionGetResponse_category_labelIntl>("labelIntl", withExtensionGetResponse_category.labelIntl, serializeWithExtensionGetResponse_category_labelIntl);
+        writer.writeNumberValue("order", withExtensionGetResponse_category.order);
     }
 }
 /**
@@ -240,6 +273,7 @@ export function serializeWithExtensionGetResponse_category_labelIntl(writer: Ser
 export function serializeWithExtensionGetResponse_destination(writer: SerializationWriter, withExtensionGetResponse_destination: Partial<WithExtensionGetResponse_destination> | undefined | null = {}) : void {
     if (withExtensionGetResponse_destination) {
         writer.writeStringValue("id", withExtensionGetResponse_destination.id);
+        writer.writeStringValue("path", withExtensionGetResponse_destination.path);
     }
 }
 /**
@@ -262,6 +296,23 @@ export function serializeWithExtensionGetResponse_menu(writer: SerializationWrit
 export function serializeWithExtensionGetResponse_menu_labelIntl(writer: SerializationWriter, withExtensionGetResponse_menu_labelIntl: Partial<WithExtensionGetResponse_menu_labelIntl> | undefined | null = {}) : void {
     if (withExtensionGetResponse_menu_labelIntl) {
         writer.writeAdditionalData(withExtensionGetResponse_menu_labelIntl.additionalData);
+    }
+}
+/**
+ * Serializes information the current object
+ * @param writer Serialization writer to use to serialize this model
+ */
+// @ts-ignore
+export function serializeWithExtensionGetResponse_proxy(writer: SerializationWriter, withExtensionGetResponse_proxy: Partial<WithExtensionGetResponse_proxy> | undefined | null = {}) : void {
+    if (withExtensionGetResponse_proxy) {
+        writer.writeStringValue("authentication", withExtensionGetResponse_proxy.authentication);
+        writer.writeStringValue("authType", withExtensionGetResponse_proxy.authType);
+        writer.writeStringValue("basePath", withExtensionGetResponse_proxy.basePath);
+        writer.writeStringValue("clientId", withExtensionGetResponse_proxy.clientId);
+        writer.writeStringValue("grantType", withExtensionGetResponse_proxy.grantType);
+        writer.writeCollectionOfPrimitiveValues<string>("headersToProxy", withExtensionGetResponse_proxy.headersToProxy);
+        writer.writeStringValue("targetBaseUrl", withExtensionGetResponse_proxy.targetBaseUrl);
+        writer.writeStringValue("username", withExtensionGetResponse_proxy.username);
     }
 }
 /**
@@ -339,6 +390,14 @@ export interface WithExtensionGetResponse extends Parsable {
      */
     permissions?: string[] | null;
     /**
+     * The proxy property
+     */
+    proxy?: WithExtensionGetResponse_proxy | null;
+    /**
+     * The roleIds property
+     */
+    roleIds?: string[] | null;
+    /**
      * The type property
      */
     type?: string | null;
@@ -356,6 +415,10 @@ export interface WithExtensionGetResponse_category extends Parsable {
      * The labelIntl property
      */
     labelIntl?: WithExtensionGetResponse_category_labelIntl | null;
+    /**
+     * The order property
+     */
+    order?: number | null;
 }
 export interface WithExtensionGetResponse_category_labelIntl extends AdditionalDataHolder, Parsable {
     /**
@@ -368,6 +431,10 @@ export interface WithExtensionGetResponse_destination extends Parsable {
      * The id property
      */
     id?: string | null;
+    /**
+     * The path property
+     */
+    path?: string | null;
 }
 export interface WithExtensionGetResponse_menu extends Parsable {
     /**
@@ -388,6 +455,40 @@ export interface WithExtensionGetResponse_menu_labelIntl extends AdditionalDataH
      * Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
      */
     additionalData?: Record<string, unknown>;
+}
+export interface WithExtensionGetResponse_proxy extends Parsable {
+    /**
+     * The authentication property
+     */
+    authentication?: string | null;
+    /**
+     * The authType property
+     */
+    authType?: string | null;
+    /**
+     * The basePath property
+     */
+    basePath?: string | null;
+    /**
+     * The clientId property
+     */
+    clientId?: string | null;
+    /**
+     * The grantType property
+     */
+    grantType?: string | null;
+    /**
+     * The headersToProxy property
+     */
+    headersToProxy?: string[] | null;
+    /**
+     * The targetBaseUrl property
+     */
+    targetBaseUrl?: string | null;
+    /**
+     * The username property
+     */
+    username?: string | null;
 }
 export interface WithExtensionGetResponse_visibilities extends Parsable {
     /**
@@ -423,7 +524,7 @@ export interface WithExtensionItemRequestBuilder extends BaseRequestBuilder<With
      * @returns {Promise<WithExtensionGetResponse>}
      * @throws {WithExtension500Error} error when the service returns a 500 status code
      */
-     get(requestConfiguration?: RequestConfiguration<object> | undefined) : Promise<WithExtensionGetResponse | undefined>;
+     get(requestConfiguration?: RequestConfiguration<WithExtensionItemRequestBuilderGetQueryParameters> | undefined) : Promise<WithExtensionGetResponse | undefined>;
     /**
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns {RequestInformation}
@@ -433,12 +534,18 @@ export interface WithExtensionItemRequestBuilder extends BaseRequestBuilder<With
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns {RequestInformation}
      */
-     toGetRequestInformation(requestConfiguration?: RequestConfiguration<object> | undefined) : RequestInformation;
+     toGetRequestInformation(requestConfiguration?: RequestConfiguration<WithExtensionItemRequestBuilderGetQueryParameters> | undefined) : RequestInformation;
+}
+export interface WithExtensionItemRequestBuilderGetQueryParameters {
+    /**
+     * `true`: include visibilities and proxies in the response. `false` only extension data is returned. default value is `false`.
+     */
+    resolveDetails?: boolean;
 }
 /**
  * Uri template for the request builder.
  */
-export const WithExtensionItemRequestBuilderUriTemplate = "{+baseurl}/api/extensibility/tenants/{tenantId}/extensions/{extensionId}";
+export const WithExtensionItemRequestBuilderUriTemplate = "{+baseurl}/api/extensibility/tenants/{tenantId}/extensions/{extensionId}{?resolveDetails*}";
 /**
  * Metadata for all the navigation properties in the request builder.
  */

--- a/packages/console-client/src/kiota-client/kiota-lock.json
+++ b/packages/console-client/src/kiota-client/kiota-lock.json
@@ -1,9 +1,10 @@
 {
-  "descriptionHash": "EDB7DE921BCDF0E6DF672469828CC3DFA539DE419D674E832453CD8D295F2D73C6B767DAE9E925D6CFD36A55627A447306D176A5AB3BCA40A266D36EB66E253F",
+  "descriptionHash": "641DC1CCA10AB081EA173747FC2A56FF69789EE3E5C433278725E0A03D84D35C0FC345C8669A437A1CFE5E7054D1960E0C645453CA29A20A23EC905F674249F0",
   "descriptionLocation": "../../oas-schema/console-apis-schema.json",
   "lockFileVersion": "1.0.0",
-  "kiotaVersion": "1.18.0",
+  "kiotaVersion": "1.20.0",
   "clientClassName": "ConsoleClient",
+  "typeAccessModifier": "Public",
   "clientNamespaceName": "ApiSdk",
   "language": "TypeScript",
   "usesBackingStore": false,


### PR DESCRIPTION
- added `proxy` information to `GET /extensions` and `GET /extensions/:extensionId` APIs
- updated extension schemas including `serverSideResolvedRoutes` and `destination.path` as well
- generated with kiota v `1.20.0`