### PR TITLE
feat: add port to custom endpoints

### DIFF
--- a/packages/console-types/src/index.ts
+++ b/packages/console-types/src/index.ts
@@ -252,6 +252,7 @@ export type { Config } from './types/config'
 
 export type {
   Endpoints,
+  CustomEndpoint,
   GenericEndpoint,
   SingleViewEndpoint,
   CrudEndpoint,

--- a/packages/console-types/src/types/endpoints.test.ts
+++ b/packages/console-types/src/types/endpoints.test.ts
@@ -980,6 +980,7 @@ const CUSTOM_ENDPOINT = {
     'allowUnknownResponseContentType': true,
     'forceMicroserviceGatewayProxy': false,
     'service': 'backend',
+    'port': '80',
   },
 }
 

--- a/packages/console-types/tap-snapshots/src/types/config.test.ts.test.cjs
+++ b/packages/console-types/tap-snapshots/src/types/config.test.ts.test.cjs
@@ -1726,10 +1726,597 @@ Object {
         "else": Object {
           "else": Object {
             "else": Object {
+              "else": Object {
+                "if": Object {
+                  "properties": Object {
+                    "type": Object {
+                      "const": "fast-data-single-view",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+                "then": Object {
+                  "properties": Object {
+                    "acl": Object {
+                      "type": "string",
+                    },
+                    "allowUnknownRequestContentType": Object {
+                      "default": false,
+                      "type": "boolean",
+                    },
+                    "allowUnknownResponseContentType": Object {
+                      "default": false,
+                      "type": "boolean",
+                    },
+                    "backofficeAcl": Object {
+                      "default": Object {
+                        "inherited": true,
+                      },
+                      "else": Object {
+                        "additionalProperties": false,
+                        "properties": Object {
+                          "inherited": Object {
+                            "const": true,
+                            "type": "boolean",
+                          },
+                        },
+                        "required": Array [
+                          "inherited",
+                        ],
+                        "type": "object",
+                      },
+                      "if": Object {
+                        "properties": Object {
+                          "inherited": Object {
+                            "const": false,
+                            "type": "boolean",
+                          },
+                        },
+                        "type": "object",
+                      },
+                      "then": Object {
+                        "additionalProperties": false,
+                        "properties": Object {
+                          "inherited": Object {
+                            "const": false,
+                            "type": "boolean",
+                          },
+                          "value": Object {
+                            "type": "string",
+                          },
+                        },
+                        "required": Array [
+                          "inherited",
+                          "value",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "object",
+                    },
+                    "basePath": Object {
+                      "pattern": "^(\\\\/$|(\\\\/([\\\\w\\\\-\\\\.]|(:[a-zA-Z]))[\\\\w\\\\-\\\\.]*)+)$",
+                      "type": "string",
+                    },
+                    "description": Object {
+                      "type": "string",
+                    },
+                    "forceMicroserviceGatewayProxy": Object {
+                      "default": false,
+                      "type": "boolean",
+                    },
+                    "internalEndpoint": Object {
+                      "type": "string",
+                    },
+                    "listeners": Object {
+                      "additionalProperties": Object {
+                        "type": "boolean",
+                      },
+                      "type": "object",
+                    },
+                    "options": Object {
+                      "properties": Object {
+                        "iframePolicy": Object {
+                          "enum": Array [
+                            "all",
+                            "deny",
+                            "sameorigin",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "pathName": Object {
+                      "pattern": "^\\\\/(([\\\\w\\\\-:])\\\\/?)*$",
+                      "type": "string",
+                    },
+                    "pathRewrite": Object {
+                      "type": "string",
+                    },
+                    "public": Object {
+                      "type": "boolean",
+                    },
+                    "rateLimit": Object {
+                      "properties": Object {
+                        "requestsPerSecond": Object {
+                          "description": "The number of request that can be made each second",
+                          "type": "integer",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "requestBody": Object {
+                      "properties": Object {
+                        "maxSizeMB": Object {
+                          "description": "Maximum size of the request body",
+                          "type": "number",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "routes": Object {
+                      "additionalProperties": Object {
+                        "additionalProperties": false,
+                        "properties": Object {
+                          "acl": Object {
+                            "default": Object {
+                              "inherited": true,
+                            },
+                            "else": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": true,
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                              ],
+                              "type": "object",
+                            },
+                            "if": Object {
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "then": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                                "value",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "object",
+                          },
+                          "allowUnknownRequestContentType": Object {
+                            "default": Object {
+                              "inherited": true,
+                            },
+                            "else": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": true,
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                              ],
+                              "type": "object",
+                            },
+                            "if": Object {
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "then": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "value": Object {
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                                "value",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "object",
+                          },
+                          "allowUnknownResponseContentType": Object {
+                            "default": Object {
+                              "inherited": true,
+                            },
+                            "else": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": true,
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                              ],
+                              "type": "object",
+                            },
+                            "if": Object {
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "then": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "value": Object {
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                                "value",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "object",
+                          },
+                          "backofficeAcl": Object {
+                            "default": Object {
+                              "inherited": true,
+                            },
+                            "else": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": true,
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                              ],
+                              "type": "object",
+                            },
+                            "if": Object {
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "then": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "value": Object {
+                                  "type": "string",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                                "value",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "object",
+                          },
+                          "catchDecorator": Object {
+                            "type": "string",
+                          },
+                          "id": Object {
+                            "type": "string",
+                          },
+                          "path": Object {
+                            "pattern": "^(\\\\/$|(\\\\/([\\\\w\\\\-\\\\.]|(:[a-zA-Z]))[\\\\w\\\\-\\\\.]*\\\\/?)+)$",
+                            "type": "string",
+                          },
+                          "postDecorators": Object {
+                            "default": Array [],
+                            "items": Object {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          "preDecorators": Object {
+                            "default": Array [],
+                            "items": Object {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          "public": Object {
+                            "default": Object {
+                              "inherited": true,
+                            },
+                            "else": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": true,
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                              ],
+                              "type": "object",
+                            },
+                            "if": Object {
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "then": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "value": Object {
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                                "value",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "object",
+                          },
+                          "rateLimit": Object {
+                            "default": Object {
+                              "inherited": true,
+                            },
+                            "else": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": true,
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                              ],
+                              "type": "object",
+                            },
+                            "if": Object {
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "then": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "requestsPerSecond": Object {
+                                  "description": "Maximum number of requests allowed per second",
+                                  "type": "number",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                                "requestsPerSecond",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "object",
+                          },
+                          "schema": Object {
+                            "type": "object",
+                          },
+                          "secreted": Object {
+                            "default": Object {
+                              "inherited": true,
+                            },
+                            "else": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": true,
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                              ],
+                              "type": "object",
+                            },
+                            "if": Object {
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "then": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "value": Object {
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                                "value",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "object",
+                          },
+                          "showInDocumentation": Object {
+                            "default": Object {
+                              "inherited": true,
+                            },
+                            "else": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": true,
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                              ],
+                              "type": "object",
+                            },
+                            "if": Object {
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "then": Object {
+                              "additionalProperties": false,
+                              "properties": Object {
+                                "inherited": Object {
+                                  "const": false,
+                                  "type": "boolean",
+                                },
+                                "value": Object {
+                                  "type": "boolean",
+                                },
+                              },
+                              "required": Array [
+                                "inherited",
+                                "value",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "object",
+                          },
+                          "verb": Object {
+                            "enum": Array [
+                              "GET",
+                              "POST",
+                              "PUT",
+                              "PATCH",
+                              "DELETE",
+                              "HEAD",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": Array [
+                          "id",
+                          "path",
+                          "acl",
+                          "backofficeAcl",
+                          "public",
+                          "secreted",
+                          "showInDocumentation",
+                          "verb",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "object",
+                    },
+                    "secreted": Object {
+                      "type": "boolean",
+                    },
+                    "showInDocumentation": Object {
+                      "type": "boolean",
+                    },
+                    "tags": Object {
+                      "items": Object {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "timeout": Object {
+                      "properties": Object {
+                        "readSeconds": Object {
+                          "description": "The number of seconds to wait before the request is rejected",
+                          "type": "number",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "type": Object {
+                      "const": "fast-data-single-view",
+                      "type": "string",
+                    },
+                  },
+                  "required": Array [
+                    "internalEndpoint",
+                    "routes",
+                    "pathName",
+                    "basePath",
+                    "type",
+                    "public",
+                    "secreted",
+                    "showInDocumentation",
+                    "acl",
+                  ],
+                  "type": "object",
+                },
+              },
               "if": Object {
                 "properties": Object {
                   "type": Object {
-                    "const": "fast-data-single-view",
+                    "const": "fast-data-projection",
                     "type": "string",
                   },
                 },
@@ -1804,9 +2391,6 @@ Object {
                     "default": false,
                     "type": "boolean",
                   },
-                  "internalEndpoint": Object {
-                    "type": "string",
-                  },
                   "listeners": Object {
                     "additionalProperties": Object {
                       "type": "boolean",
@@ -1831,6 +2415,9 @@ Object {
                     "type": "string",
                   },
                   "pathRewrite": Object {
+                    "type": "string",
+                  },
+                  "projectionId": Object {
                     "type": "string",
                   },
                   "public": Object {
@@ -2294,12 +2881,12 @@ Object {
                     "type": "object",
                   },
                   "type": Object {
-                    "const": "fast-data-single-view",
+                    "const": "fast-data-projection",
                     "type": "string",
                   },
                 },
                 "required": Array [
-                  "internalEndpoint",
+                  "projectionId",
                   "routes",
                   "pathName",
                   "basePath",
@@ -2315,7 +2902,11 @@ Object {
             "if": Object {
               "properties": Object {
                 "type": Object {
-                  "const": "fast-data-projection",
+                  "enum": Array [
+                    "external",
+                    "custom",
+                    "cross-projects",
+                  ],
                   "type": "string",
                 },
               },
@@ -2409,14 +3000,7 @@ Object {
                   },
                   "type": "object",
                 },
-                "pathName": Object {
-                  "pattern": "^\\\\/(([\\\\w\\\\-:])\\\\/?)*$",
-                  "type": "string",
-                },
                 "pathRewrite": Object {
-                  "type": "string",
-                },
-                "projectionId": Object {
                   "type": "string",
                 },
                 "public": Object {
@@ -2861,6 +3445,12 @@ Object {
                 "secreted": Object {
                   "type": "boolean",
                 },
+                "service": Object {
+                  "minLength": 1,
+                  "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+                  "type": "string",
+                  "x-validation-error-id": "resourceName.patternError",
+                },
                 "showInDocumentation": Object {
                   "type": "boolean",
                 },
@@ -2880,14 +3470,16 @@ Object {
                   "type": "object",
                 },
                 "type": Object {
-                  "const": "fast-data-projection",
+                  "enum": Array [
+                    "external",
+                    "custom",
+                    "cross-projects",
+                  ],
                   "type": "string",
                 },
               },
               "required": Array [
-                "projectionId",
-                "routes",
-                "pathName",
+                "service",
                 "basePath",
                 "type",
                 "public",
@@ -2901,11 +3493,7 @@ Object {
           "if": Object {
             "properties": Object {
               "type": Object {
-                "enum": Array [
-                  "external",
-                  "custom",
-                  "cross-projects",
-                ],
+                "const": "custom",
                 "type": "string",
               },
             },
@@ -3000,6 +3588,11 @@ Object {
                 "type": "object",
               },
               "pathRewrite": Object {
+                "type": "string",
+              },
+              "port": Object {
+                "minLength": 1,
+                "pattern": "^$|^((\\\\{\\\\{([A-Z])([A-Z0-9_]*)\\\\}\\\\})|([1-9]\\\\d*|0))$",
                 "type": "string",
               },
               "public": Object {
@@ -3469,16 +4062,16 @@ Object {
                 "type": "object",
               },
               "type": Object {
-                "enum": Array [
-                  "external",
-                  "custom",
-                  "cross-projects",
-                ],
+                "const": "custom",
                 "type": "string",
+              },
+              "useDownstreamProtocol": Object {
+                "type": "boolean",
               },
             },
             "required": Array [
               "service",
+              "port",
               "basePath",
               "type",
               "public",

--- a/packages/console-types/tap-snapshots/src/types/endpoints.test.ts.test.cjs
+++ b/packages/console-types/tap-snapshots/src/types/endpoints.test.ts.test.cjs
@@ -610,11 +610,7 @@ exports[`src/types/endpoints.test.ts TAP endpoints schema > must match snapshot 
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "external",
-              "custom",
-              "cross-projects"
-            ]
+            "const": "custom"
           }
         }
       },
@@ -1051,11 +1047,7 @@ exports[`src/types/endpoints.test.ts TAP endpoints schema > must match snapshot 
           },
           "type": {
             "type": "string",
-            "enum": [
-              "external",
-              "custom",
-              "cross-projects"
-            ]
+            "const": "custom"
           },
           "tags": {
             "type": "array",
@@ -1183,10 +1175,19 @@ exports[`src/types/endpoints.test.ts TAP endpoints schema > must match snapshot 
             "minLength": 1,
             "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
             "x-validation-error-id": "resourceName.patternError"
+          },
+          "port": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^$|^((\\\\{\\\\{([A-Z])([A-Z0-9_]*)\\\\}\\\\})|([1-9]\\\\d*|0))$"
+          },
+          "useDownstreamProtocol": {
+            "type": "boolean"
           }
         },
         "required": [
           "service",
+          "port",
           "basePath",
           "type",
           "public",
@@ -1201,7 +1202,11 @@ exports[`src/types/endpoints.test.ts TAP endpoints schema > must match snapshot 
           "properties": {
             "type": {
               "type": "string",
-              "const": "fast-data-projection"
+              "enum": [
+                "external",
+                "custom",
+                "cross-projects"
+              ]
             }
           }
         },
@@ -1638,7 +1643,11 @@ exports[`src/types/endpoints.test.ts TAP endpoints schema > must match snapshot 
             },
             "type": {
               "type": "string",
-              "const": "fast-data-projection"
+              "enum": [
+                "external",
+                "custom",
+                "cross-projects"
+              ]
             },
             "tags": {
               "type": "array",
@@ -1761,18 +1770,15 @@ exports[`src/types/endpoints.test.ts TAP endpoints schema > must match snapshot 
                 }
               }
             },
-            "pathName": {
+            "service": {
               "type": "string",
-              "pattern": "^\\\\/(([\\\\w\\\\-:])\\\\/?)*$"
-            },
-            "projectionId": {
-              "type": "string"
+              "minLength": 1,
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+              "x-validation-error-id": "resourceName.patternError"
             }
           },
           "required": [
-            "projectionId",
-            "routes",
-            "pathName",
+            "service",
             "basePath",
             "type",
             "public",
@@ -1787,7 +1793,7 @@ exports[`src/types/endpoints.test.ts TAP endpoints schema > must match snapshot 
             "properties": {
               "type": {
                 "type": "string",
-                "const": "fast-data-single-view"
+                "const": "fast-data-projection"
               }
             }
           },
@@ -2224,7 +2230,7 @@ exports[`src/types/endpoints.test.ts TAP endpoints schema > must match snapshot 
               },
               "type": {
                 "type": "string",
-                "const": "fast-data-single-view"
+                "const": "fast-data-projection"
               },
               "tags": {
                 "type": "array",
@@ -2351,12 +2357,12 @@ exports[`src/types/endpoints.test.ts TAP endpoints schema > must match snapshot 
                 "type": "string",
                 "pattern": "^\\\\/(([\\\\w\\\\-:])\\\\/?)*$"
               },
-              "internalEndpoint": {
+              "projectionId": {
                 "type": "string"
               }
             },
             "required": [
-              "internalEndpoint",
+              "projectionId",
               "routes",
               "pathName",
               "basePath",
@@ -2366,6 +2372,593 @@ exports[`src/types/endpoints.test.ts TAP endpoints schema > must match snapshot 
               "showInDocumentation",
               "acl"
             ]
+          },
+          "else": {
+            "if": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "fast-data-single-view"
+                }
+              }
+            },
+            "then": {
+              "type": "object",
+              "properties": {
+                "basePath": {
+                  "type": "string",
+                  "pattern": "^(\\\\/$|(\\\\/([\\\\w\\\\-\\\\.]|(:[a-zA-Z]))[\\\\w\\\\-\\\\.]*)+)$"
+                },
+                "pathRewrite": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "routes": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string",
+                        "pattern": "^(\\\\/$|(\\\\/([\\\\w\\\\-\\\\.]|(:[a-zA-Z]))[\\\\w\\\\-\\\\.]*\\\\/?)+)$"
+                      },
+                      "public": {
+                        "type": "object",
+                        "default": {
+                          "inherited": true
+                        },
+                        "if": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            }
+                          }
+                        },
+                        "then": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            },
+                            "value": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "inherited",
+                            "value"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "else": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": true
+                            }
+                          },
+                          "required": [
+                            "inherited"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "showInDocumentation": {
+                        "type": "object",
+                        "default": {
+                          "inherited": true
+                        },
+                        "if": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            }
+                          }
+                        },
+                        "then": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            },
+                            "value": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "inherited",
+                            "value"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "else": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": true
+                            }
+                          },
+                          "required": [
+                            "inherited"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "schema": {
+                        "type": "object"
+                      },
+                      "secreted": {
+                        "type": "object",
+                        "default": {
+                          "inherited": true
+                        },
+                        "if": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            }
+                          }
+                        },
+                        "then": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            },
+                            "value": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "inherited",
+                            "value"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "else": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": true
+                            }
+                          },
+                          "required": [
+                            "inherited"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "allowUnknownRequestContentType": {
+                        "type": "object",
+                        "default": {
+                          "inherited": true
+                        },
+                        "if": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            }
+                          }
+                        },
+                        "then": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            },
+                            "value": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "inherited",
+                            "value"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "else": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": true
+                            }
+                          },
+                          "required": [
+                            "inherited"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "allowUnknownResponseContentType": {
+                        "type": "object",
+                        "default": {
+                          "inherited": true
+                        },
+                        "if": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            }
+                          }
+                        },
+                        "then": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            },
+                            "value": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "inherited",
+                            "value"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "else": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": true
+                            }
+                          },
+                          "required": [
+                            "inherited"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "acl": {
+                        "type": "object",
+                        "default": {
+                          "inherited": true
+                        },
+                        "if": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            }
+                          }
+                        },
+                        "then": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "inherited",
+                            "value"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "else": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": true
+                            }
+                          },
+                          "required": [
+                            "inherited"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "backofficeAcl": {
+                        "type": "object",
+                        "default": {
+                          "inherited": true
+                        },
+                        "if": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            }
+                          }
+                        },
+                        "then": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "inherited",
+                            "value"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "else": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": true
+                            }
+                          },
+                          "required": [
+                            "inherited"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "verb": {
+                        "type": "string",
+                        "enum": [
+                          "GET",
+                          "POST",
+                          "PUT",
+                          "PATCH",
+                          "DELETE",
+                          "HEAD"
+                        ]
+                      },
+                      "catchDecorator": {
+                        "type": "string"
+                      },
+                      "preDecorators": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "default": []
+                      },
+                      "postDecorators": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "default": []
+                      },
+                      "rateLimit": {
+                        "type": "object",
+                        "default": {
+                          "inherited": true
+                        },
+                        "if": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            }
+                          }
+                        },
+                        "then": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": false
+                            },
+                            "requestsPerSecond": {
+                              "type": "number",
+                              "description": "Maximum number of requests allowed per second"
+                            }
+                          },
+                          "required": [
+                            "inherited",
+                            "requestsPerSecond"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "else": {
+                          "type": "object",
+                          "properties": {
+                            "inherited": {
+                              "type": "boolean",
+                              "const": true
+                            }
+                          },
+                          "required": [
+                            "inherited"
+                          ],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "id",
+                      "path",
+                      "acl",
+                      "backofficeAcl",
+                      "public",
+                      "secreted",
+                      "showInDocumentation",
+                      "verb"
+                    ]
+                  }
+                },
+                "type": {
+                  "type": "string",
+                  "const": "fast-data-single-view"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "public": {
+                  "type": "boolean"
+                },
+                "showInDocumentation": {
+                  "type": "boolean"
+                },
+                "secreted": {
+                  "type": "boolean"
+                },
+                "acl": {
+                  "type": "string"
+                },
+                "backofficeAcl": {
+                  "type": "object",
+                  "default": {
+                    "inherited": true
+                  },
+                  "if": {
+                    "type": "object",
+                    "properties": {
+                      "inherited": {
+                        "type": "boolean",
+                        "const": false
+                      }
+                    }
+                  },
+                  "then": {
+                    "type": "object",
+                    "properties": {
+                      "inherited": {
+                        "type": "boolean",
+                        "const": false
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "inherited",
+                      "value"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "else": {
+                    "type": "object",
+                    "properties": {
+                      "inherited": {
+                        "type": "boolean",
+                        "const": true
+                      }
+                    },
+                    "required": [
+                      "inherited"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "allowUnknownRequestContentType": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "allowUnknownResponseContentType": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "forceMicroserviceGatewayProxy": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "timeout": {
+                  "type": "object",
+                  "properties": {
+                    "readSeconds": {
+                      "type": "number",
+                      "description": "The number of seconds to wait before the request is rejected"
+                    }
+                  }
+                },
+                "rateLimit": {
+                  "type": "object",
+                  "properties": {
+                    "requestsPerSecond": {
+                      "type": "integer",
+                      "description": "The number of request that can be made each second"
+                    }
+                  }
+                },
+                "requestBody": {
+                  "type": "object",
+                  "properties": {
+                    "maxSizeMB": {
+                      "type": "number",
+                      "description": "Maximum size of the request body"
+                    }
+                  }
+                },
+                "listeners": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "boolean"
+                  }
+                },
+                "options": {
+                  "type": "object",
+                  "properties": {
+                    "iframePolicy": {
+                      "type": "string",
+                      "enum": [
+                        "all",
+                        "deny",
+                        "sameorigin"
+                      ]
+                    }
+                  }
+                },
+                "pathName": {
+                  "type": "string",
+                  "pattern": "^\\\\/(([\\\\w\\\\-:])\\\\/?)*$"
+                },
+                "internalEndpoint": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "internalEndpoint",
+                "routes",
+                "pathName",
+                "basePath",
+                "type",
+                "public",
+                "secreted",
+                "showInDocumentation",
+                "acl"
+              ]
+            }
           }
         }
       }


### PR DESCRIPTION
The following PR adds a new field, `port`, required, on any endpoint where type is `custom`.