### PR TITLE
fix: add missing TS type in endpoints

### DIFF
--- a/.changeset/silver-clocks-appear.md
+++ b/.changeset/silver-clocks-appear.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+fix: add missing TS type in endpoints

--- a/packages/console-types/src/types/endpoints.ts
+++ b/packages/console-types/src/types/endpoints.ts
@@ -347,8 +347,9 @@ export const endpoints = {
 
 // This type is required since Endpoints cannot parse if/then/else since it is too deep
 export type Endpoints = Record<string,
-FastDataProjectionEndpoint |
-CrudEndpoint |
-SingleViewEndpoint |
-GenericEndpoint
+  FastDataProjectionEndpoint |
+  CrudEndpoint |
+  SingleViewEndpoint |
+  CustomEndpoint |
+  GenericEndpoint
 >


### PR DESCRIPTION
Minor fix on the `console-types` package, where the `CustomEndpoint` typescript type was not exported.