### PR TITLE
feat(types): Added `repositoryUrl` to catalog items resources schema

### DIFF
--- a/.changeset/curvy-crabs-fail.md
+++ b/.changeset/curvy-crabs-fail.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-client": patch
+---
+
+Updated Kiota libraries to version `1.0.0-preview.81`

--- a/.changeset/many-mangos-deliver.md
+++ b/.changeset/many-mangos-deliver.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+Added repositoryUrl to catalog items resources schema

--- a/packages/console-client/package.json
+++ b/packages/console-client/package.json
@@ -18,11 +18,11 @@
   },
   "author": "",
   "dependencies": {
-    "@microsoft/kiota-abstractions": "1.0.0-preview.66",
-    "@microsoft/kiota-serialization-json": "1.0.0-preview.66",
-    "@microsoft/kiota-serialization-text": "1.0.0-preview.63",
-    "@microsoft/kiota-serialization-form": "1.0.0-preview.54",
-    "@microsoft/kiota-serialization-multipart": "1.0.0-preview.44",
+    "@microsoft/kiota-abstractions": "1.0.0-preview.81",
+    "@microsoft/kiota-serialization-json": "1.0.0-preview.81",
+    "@microsoft/kiota-serialization-text": "1.0.0-preview.81",
+    "@microsoft/kiota-serialization-form": "1.0.0-preview.81",
+    "@microsoft/kiota-serialization-multipart": "1.0.0-preview.81",
     "axios": "^1.7.7"
   },
   "devDependencies": {

--- a/packages/console-types/package.json
+++ b/packages/console-types/package.json
@@ -41,6 +41,7 @@
     ]
   },
   "dependencies": {
+    "@types/json-schema": "^7.0.9",
     "ramda": "^0.30.1"
   },
   "peerDependencies": {

--- a/packages/console-types/src/commons/json-schema.ts
+++ b/packages/console-types/src/commons/json-schema.ts
@@ -1,3 +1,21 @@
+/**
+ * Copyright 2025 Mia srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import type { JSONSchema7TypeName, JSONSchema7 as OriginalJSONSchema7 } from 'json-schema'
 
 declare const $JSONSchema7: unique symbol

--- a/packages/console-types/src/commons/json-schema.ts
+++ b/packages/console-types/src/commons/json-schema.ts
@@ -1,0 +1,37 @@
+import type { JSONSchema7TypeName, JSONSchema7 as OriginalJSONSchema7 } from 'json-schema'
+
+declare const $JSONSchema7: unique symbol
+
+type $JSONSchema7 = typeof $JSONSchema7
+
+type PropsToOverride = 'type' | 'const' | 'enum' | 'items' | 'additionalItems' | 'contains' | 'properties' | 'required' | 'patternProperties' | 'additionalProperties' | 'dependencies' | 'propertyNames' | 'if' | 'then' | 'else' | 'allOf' | 'anyOf' | 'oneOf' | 'not' | 'definitions' | 'examples' | 'default'
+
+type JSONSchema7 = boolean | (Omit<OriginalJSONSchema7, PropsToOverride> & Readonly<{
+  [$JSONSchema7]?: $JSONSchema7;
+  type?: JSONSchema7TypeName | readonly JSONSchema7TypeName[];
+  const?: unknown;
+  enum?: unknown;
+  items?: JSONSchema7 | readonly JSONSchema7[];
+  additionalItems?: JSONSchema7;
+  contains?: JSONSchema7;
+  properties?: Readonly<Record<string, JSONSchema7>>;
+  required?: readonly string[];
+  patternProperties?: Readonly<Record<string, JSONSchema7>>;
+  additionalProperties?: JSONSchema7;
+  dependencies?: Readonly<Record<string, JSONSchema7 | readonly string[]>>;
+  propertyNames?: JSONSchema7;
+  if?: JSONSchema7;
+  then?: JSONSchema7;
+  else?: JSONSchema7;
+  allOf?: readonly JSONSchema7[];
+  anyOf?: readonly JSONSchema7[];
+  oneOf?: readonly JSONSchema7[];
+  not?: JSONSchema7;
+  nullable?: boolean;
+  definitions?: Readonly<Record<string, JSONSchema7>>;
+  examples?: readonly unknown[];
+  default?: unknown;
+  deprecated?: boolean
+}>)
+
+export type JSONSchema = JSONSchema7

--- a/packages/console-types/src/types/catalog/category.ts
+++ b/packages/console-types/src/types/catalog/category.ts
@@ -16,7 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { FromSchema, JSONSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
+
+import type { JSONSchema } from '../../commons/json-schema'
 
 export const catalogCategorySchema = {
   $id: 'catalog-category.schema.json',

--- a/packages/console-types/src/types/catalog/commons.ts
+++ b/packages/console-types/src/types/catalog/commons.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema } from 'json-schema-to-ts'
+import type { JSONSchema } from '../../commons/json-schema'
 
 export const NA_VERSION = 'NA'
 

--- a/packages/console-types/src/types/catalog/item-manifest.ts
+++ b/packages/console-types/src/types/catalog/item-manifest.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema, FromSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import type { JSONSchema } from '../../commons/json-schema'
 import {
   catalogComingSoonSchema,
   catalogDescriptionSchema,

--- a/packages/console-types/src/types/catalog/item.ts
+++ b/packages/console-types/src/types/catalog/item.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { FromSchema, JSONSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import type { JSONSchema } from '../../commons/json-schema'
 import {
   catalogComingSoonSchema,
   catalogDescriptionSchema,

--- a/packages/console-types/src/types/catalog/release.ts
+++ b/packages/console-types/src/types/catalog/release.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { FromSchema, JSONSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import type { JSONSchema } from '../../commons/json-schema'
 import {
   catalogComingSoonSchema,
   catalogDescriptionSchema,

--- a/packages/console-types/src/types/catalog/versioned-item.ts
+++ b/packages/console-types/src/types/catalog/versioned-item.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { FromSchema, JSONSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import type { JSONSchema } from '../../commons/json-schema'
 import { catalogVersionSchema } from './commons'
 import { catalogItemSchema } from './item'
 

--- a/packages/console-types/src/types/catalog/well-known-items/application/collection.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/application/collection.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema } from 'json-schema-to-ts'
+import type { JSONSchema } from '../../../../commons/json-schema'
 
 const collectionNameSchema = {
   maxLength: 80,

--- a/packages/console-types/src/types/catalog/well-known-items/application/endpoint.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/application/endpoint.ts
@@ -16,8 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema } from 'json-schema-to-ts'
-
+import type { JSONSchema } from '../../../../commons/json-schema'
 import { tagsSchema } from '../commons'
 
 const defaultBasePathSchema = { pattern: '^(\\/$|(\\/([\\w\\-\\.]|(:[a-zA-Z]))[\\w\\-\\.]*)+)$', type: 'string' } as const satisfies JSONSchema

--- a/packages/console-types/src/types/catalog/well-known-items/application/index.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/application/index.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema, FromSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import type { JSONSchema } from '../../../../commons/json-schema'
 import { catalogExampleSchema } from '../example'
 import { catalogPluginSchema } from '../plugin'
 import { catalogTemplateSchema } from '../template'

--- a/packages/console-types/src/types/catalog/well-known-items/application/manifest.schema.json
+++ b/packages/console-types/src/types/catalog/well-known-items/application/manifest.schema.json
@@ -2103,6 +2103,11 @@
                     "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                     "type": "string"
                   },
+                  "repositoryUrl": {
+                    "format": "uri-reference",
+                    "type": "string",
+                    "deprecated": true
+                  },
                   "type": {
                     "const": "plugin"
                   }
@@ -2842,6 +2847,11 @@
                     },
                     "type": "object"
                   },
+                  "repositoryUrl": {
+                    "format": "uri-reference",
+                    "type": "string",
+                    "deprecated": true
+                  },
                   "type": {
                     "const": "example"
                   }
@@ -3580,6 +3590,11 @@
                       }
                     },
                     "type": "object"
+                  },
+                  "repositoryUrl": {
+                    "format": "uri-reference",
+                    "type": "string",
+                    "deprecated": true
                   },
                   "type": {
                     "const": "template"

--- a/packages/console-types/src/types/catalog/well-known-items/application/unsecreted-variable.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/application/unsecreted-variable.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema } from 'json-schema-to-ts'
+import type { JSONSchema } from '../../../../commons/json-schema'
 
 export const unsecretedVariableSchema = {
   additionalProperties: false,

--- a/packages/console-types/src/types/catalog/well-known-items/commons.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/commons.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema } from 'json-schema-to-ts'
+import type { JSONSchema } from '../../../commons/json-schema'
 
 export const nameSchema = {
   minLength: 1,

--- a/packages/console-types/src/types/catalog/well-known-items/crd/index.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/crd/index.ts
@@ -16,7 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema, FromSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
+
+import type { JSONSchema } from '../../../../commons/json-schema'
 
 const type = 'custom-resource-definition'
 

--- a/packages/console-types/src/types/catalog/well-known-items/example/index.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/example/index.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema, FromSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import type { JSONSchema } from '../../../../commons/json-schema'
 import {
   archiveUrlSchema,
   containerPortsSchema,
@@ -36,6 +37,7 @@ import {
   descriptionSchema,
   nameSchema,
   pipelinesSchema,
+  repositoryUrlSchema,
 } from '../commons'
 
 const type = 'example'
@@ -60,6 +62,9 @@ export const catalogExampleSchema = {
     description: descriptionSchema,
     name: nameSchema,
     pipelines: pipelinesSchema,
+
+    /** @deprecated */
+    repositoryUrl: { ...repositoryUrlSchema, deprecated: true },
     type: { const: type },
   },
   required: ['name', 'type', 'archiveUrl'],

--- a/packages/console-types/src/types/catalog/well-known-items/example/manifest.schema.json
+++ b/packages/console-types/src/types/catalog/well-known-items/example/manifest.schema.json
@@ -817,6 +817,11 @@
                 },
                 "type": "object"
               },
+              "repositoryUrl": {
+                "format": "uri-reference",
+                "type": "string",
+                "deprecated": true
+              },
               "type": {
                 "const": "example"
               }

--- a/packages/console-types/src/types/catalog/well-known-items/extension/index.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/extension/index.ts
@@ -16,7 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema, FromSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
+
+import type { JSONSchema } from '../../../../commons/json-schema'
 
 const type = 'extension'
 

--- a/packages/console-types/src/types/catalog/well-known-items/index.test.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/index.test.ts
@@ -21,7 +21,8 @@ import t from 'tap'
 import addFormats from 'ajv-formats'
 import fs from 'fs/promises'
 import path from 'path'
-import { JSONSchema } from 'json-schema-to-ts'
+
+import type { JSONSchema } from '../../../commons/json-schema'
 
 type ItemModule = {
   default: {

--- a/packages/console-types/src/types/catalog/well-known-items/infrastructure-resource/index.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/infrastructure-resource/index.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema, FromSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import type { JSONSchema } from '../../../../commons/json-schema'
 import { nameSchema } from '../commons'
 
 const type = 'custom-resource'

--- a/packages/console-types/src/types/catalog/well-known-items/plugin/index.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/plugin/index.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema, FromSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import { JSONSchema } from '../../../../commons/json-schema'
 import {
   additionalContainersSchema,
   componentIdSchema,
@@ -38,6 +39,7 @@ import {
   dockerImageSchema,
   linksSchema,
   nameSchema,
+  repositoryUrlSchema,
 } from '../commons'
 
 const type = 'plugin'
@@ -64,6 +66,9 @@ export const catalogPluginSchema = {
     dockerImage: dockerImageSchema,
     links: linksSchema,
     name: nameSchema,
+
+    /** @deprecated */
+    repositoryUrl: { ...repositoryUrlSchema, deprecated: true },
     type: { const: 'plugin' },
   },
   required: ['name', 'type', 'dockerImage'],

--- a/packages/console-types/src/types/catalog/well-known-items/plugin/manifest.schema.json
+++ b/packages/console-types/src/types/catalog/well-known-items/plugin/manifest.schema.json
@@ -1205,6 +1205,11 @@
                 "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
                 "type": "string"
               },
+              "repositoryUrl": {
+                "format": "uri-reference",
+                "type": "string",
+                "deprecated": true
+              },
               "type": {
                 "const": "plugin"
               }

--- a/packages/console-types/src/types/catalog/well-known-items/proxy/index.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/proxy/index.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema, FromSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import type { JSONSchema } from '../../../../commons/json-schema'
 import { host } from '../../../services'
 import { defaultHeadersSchema, nameSchema, descriptionSchema } from '../commons'
 

--- a/packages/console-types/src/types/catalog/well-known-items/sidecar/index.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/sidecar/index.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema, FromSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import type { JSONSchema } from '../../../../commons/json-schema'
 import {
   componentIdSchema,
   containerPortsSchema,

--- a/packages/console-types/src/types/catalog/well-known-items/template/index.ts
+++ b/packages/console-types/src/types/catalog/well-known-items/template/index.ts
@@ -16,8 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema, FromSchema } from 'json-schema-to-ts'
+import type { FromSchema } from 'json-schema-to-ts'
 
+import type { JSONSchema } from '../../../../commons/json-schema'
 import {
   archiveUrlSchema,
   containerPortsSchema,
@@ -36,6 +37,7 @@ import {
   descriptionSchema,
   nameSchema,
   pipelinesSchema,
+  repositoryUrlSchema,
 } from '../commons'
 
 const type = 'template'
@@ -60,6 +62,9 @@ export const catalogTemplateSchema = {
     description: descriptionSchema,
     name: nameSchema,
     pipelines: pipelinesSchema,
+
+    /** @deprecated */
+    repositoryUrl: { ...repositoryUrlSchema, deprecated: true },
     type: { const: 'template' },
   },
   required: ['name', 'type', 'archiveUrl'],

--- a/packages/console-types/src/types/catalog/well-known-items/template/manifest.schema.json
+++ b/packages/console-types/src/types/catalog/well-known-items/template/manifest.schema.json
@@ -817,6 +817,11 @@
                 },
                 "type": "object"
               },
+              "repositoryUrl": {
+                "format": "uri-reference",
+                "type": "string",
+                "deprecated": true
+              },
               "type": {
                 "const": "template"
               }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@fastify/swagger':
         specifier: ^8 || ^6
         version: 8.15.0
+      '@types/json-schema':
+        specifier: ^7.0.9
+        version: 7.0.15
       fastify:
         specifier: ^4 || ^3
         version: 4.28.1
@@ -962,8 +965,8 @@ packages:
   '@microsoft/kiota-abstractions@1.0.0-preview.66':
     resolution: {integrity: sha512-mP7P+aHVLhT5A0A1nhpPQvghwNtMO9+LOV6RKYHzhzmKAvycM2rOMCpxsivHn+vtOArTiAqdfyePCpUhzziRjg==}
 
-  '@microsoft/kiota-abstractions@1.0.0-preview.70':
-    resolution: {integrity: sha512-IWc26z0EXTtm1sE7Oc035dUz4PxWCZN8iQ0btoctstjcN504Y4tQsfeut1EnI4AW8hD97Pp342lqvBuDt28bwQ==}
+  '@microsoft/kiota-abstractions@1.0.0-preview.81':
+    resolution: {integrity: sha512-3ozFMVvGGQPx34mKuJi6w81wOm6q8rm0UMXwYhaXT4gFJCoCmEu8YQIPVakdO4x0/HVPRRmWxilymru5Oa9XIw==}
 
   '@microsoft/kiota-serialization-form@1.0.0-preview.54':
     resolution: {integrity: sha512-Yd8GOae8zq3AK2koMK3RjLDzMfVRf+bx2je/MMZlUOrfKXF1rnaCWcXiyJJRlreawDI9WSeuD0mY/+pUTxSOsw==}
@@ -1096,8 +1099,8 @@ packages:
   '@std-uritemplate/std-uritemplate@1.0.5':
     resolution: {integrity: sha512-3LHrjMZXHb0gRgSYTypFPew27Fd8t8l/3zSnQncetnNiLMkBF6P7Q7O+1otQqQDCK8dzAuh2C6lSb35H+xYizw==}
 
-  '@std-uritemplate/std-uritemplate@1.0.6':
-    resolution: {integrity: sha512-+S9kAqK60nZZyvhvesoXut6NB9qB80VTpNsdiOeHmE0FAMOEsJy9/dakDL3xMp3kNRFvviw0mX9WPSuasvSxCQ==}
+  '@std-uritemplate/std-uritemplate@2.0.1':
+    resolution: {integrity: sha512-HC5kiXCa7Mxrv7SI7qH4ECfC1H+vFG15COBtX8aUur8EGEWK17RH3QVyBxtyjUXE448O4fGhQHh3kirEvPGWjw==}
 
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
@@ -3652,6 +3655,10 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
+  uuid@11.0.5:
+    resolution: {integrity: sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==}
+    hasBin: true
+
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
@@ -4653,36 +4660,35 @@ snapshots:
       tslib: 2.7.0
       uuid: 10.0.0
 
-  '@microsoft/kiota-abstractions@1.0.0-preview.70':
+  '@microsoft/kiota-abstractions@1.0.0-preview.81':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@std-uritemplate/std-uritemplate': 1.0.6
-      guid-typescript: 1.0.9
+      '@std-uritemplate/std-uritemplate': 2.0.1
       tinyduration: 3.3.1
       tslib: 2.7.0
-      uuid: 10.0.0
+      uuid: 11.0.5
 
   '@microsoft/kiota-serialization-form@1.0.0-preview.54':
     dependencies:
-      '@microsoft/kiota-abstractions': 1.0.0-preview.70
+      '@microsoft/kiota-abstractions': 1.0.0-preview.81
       guid-typescript: 1.0.9
       tslib: 2.7.0
 
   '@microsoft/kiota-serialization-json@1.0.0-preview.66':
     dependencies:
-      '@microsoft/kiota-abstractions': 1.0.0-preview.70
+      '@microsoft/kiota-abstractions': 1.0.0-preview.81
       guid-typescript: 1.0.9
       tslib: 2.7.0
 
   '@microsoft/kiota-serialization-multipart@1.0.0-preview.44':
     dependencies:
-      '@microsoft/kiota-abstractions': 1.0.0-preview.70
+      '@microsoft/kiota-abstractions': 1.0.0-preview.81
       guid-typescript: 1.0.9
       tslib: 2.7.0
 
   '@microsoft/kiota-serialization-text@1.0.0-preview.63':
     dependencies:
-      '@microsoft/kiota-abstractions': 1.0.0-preview.70
+      '@microsoft/kiota-abstractions': 1.0.0-preview.81
       guid-typescript: 1.0.9
       tslib: 2.7.0
 
@@ -4767,7 +4773,7 @@ snapshots:
 
   '@std-uritemplate/std-uritemplate@1.0.5': {}
 
-  '@std-uritemplate/std-uritemplate@1.0.6': {}
+  '@std-uritemplate/std-uritemplate@2.0.1': {}
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -7780,6 +7786,8 @@ snapshots:
       requires-port: 1.0.0
 
   uuid@10.0.0: {}
+
+  uuid@11.0.5: {}
 
   uuid@8.3.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,20 +42,20 @@ importers:
   packages/console-client:
     dependencies:
       '@microsoft/kiota-abstractions':
-        specifier: 1.0.0-preview.66
-        version: 1.0.0-preview.66
+        specifier: 1.0.0-preview.81
+        version: 1.0.0-preview.81
       '@microsoft/kiota-serialization-form':
-        specifier: 1.0.0-preview.54
-        version: 1.0.0-preview.54
+        specifier: 1.0.0-preview.81
+        version: 1.0.0-preview.81
       '@microsoft/kiota-serialization-json':
-        specifier: 1.0.0-preview.66
-        version: 1.0.0-preview.66
+        specifier: 1.0.0-preview.81
+        version: 1.0.0-preview.81
       '@microsoft/kiota-serialization-multipart':
-        specifier: 1.0.0-preview.44
-        version: 1.0.0-preview.44
+        specifier: 1.0.0-preview.81
+        version: 1.0.0-preview.81
       '@microsoft/kiota-serialization-text':
-        specifier: 1.0.0-preview.63
-        version: 1.0.0-preview.63
+        specifier: 1.0.0-preview.81
+        version: 1.0.0-preview.81
       axios:
         specifier: ^1.7.7
         version: 1.7.7
@@ -962,23 +962,20 @@ packages:
     peerDependencies:
       eslint: '>=6.8.0'
 
-  '@microsoft/kiota-abstractions@1.0.0-preview.66':
-    resolution: {integrity: sha512-mP7P+aHVLhT5A0A1nhpPQvghwNtMO9+LOV6RKYHzhzmKAvycM2rOMCpxsivHn+vtOArTiAqdfyePCpUhzziRjg==}
-
   '@microsoft/kiota-abstractions@1.0.0-preview.81':
     resolution: {integrity: sha512-3ozFMVvGGQPx34mKuJi6w81wOm6q8rm0UMXwYhaXT4gFJCoCmEu8YQIPVakdO4x0/HVPRRmWxilymru5Oa9XIw==}
 
-  '@microsoft/kiota-serialization-form@1.0.0-preview.54':
-    resolution: {integrity: sha512-Yd8GOae8zq3AK2koMK3RjLDzMfVRf+bx2je/MMZlUOrfKXF1rnaCWcXiyJJRlreawDI9WSeuD0mY/+pUTxSOsw==}
+  '@microsoft/kiota-serialization-form@1.0.0-preview.81':
+    resolution: {integrity: sha512-2YUHD2AurzUVXOKCim3Gp3PIYquu2sup6U8SU1XDTSwYKIjENZBc6sHX1/jJTxsa67UrRHk0YoxLVLt0e5I2lQ==}
 
-  '@microsoft/kiota-serialization-json@1.0.0-preview.66':
-    resolution: {integrity: sha512-H9ja9wu+e68jlzqQ548Dcu5U18dh3HAEnPcrypG+YDzgpXqXJwujZa7fOzKbR3mNRD3coUT7H9PMQfaNGZus+g==}
+  '@microsoft/kiota-serialization-json@1.0.0-preview.81':
+    resolution: {integrity: sha512-Qi6ueppLTEXvaktyZug1tLg+z+EIsyhRvaOkCsYzROdnRosJSkRA2muUYkExgAc/S+vtQTp+sTvrtLOHfL6Dmw==}
 
-  '@microsoft/kiota-serialization-multipart@1.0.0-preview.44':
-    resolution: {integrity: sha512-+g/1euy/iZXxQPlmN6zX4rkas47BShFI7bK47jLIdt6VFtZU6deWjiplnTpfR2dGg3ipQAD9RBdU4mHVoqx1Ow==}
+  '@microsoft/kiota-serialization-multipart@1.0.0-preview.81':
+    resolution: {integrity: sha512-2IWeJrL0L285O9BYrALcI9+5T9uuvTf/Ip8udmOYlhfjHMg/gxS7U3rM3a6NKWSBBHqGaUQMDY+aDRLJE58yOQ==}
 
-  '@microsoft/kiota-serialization-text@1.0.0-preview.63':
-    resolution: {integrity: sha512-tfbsG7EYukBLECdcd2UVJglOVhjjjmqUtxosZ/B/oiYAKCyooPwdOLDM5WmM4Vcgm6rMaCOaEluPKQMjfhD3xg==}
+  '@microsoft/kiota-serialization-text@1.0.0-preview.81':
+    resolution: {integrity: sha512-Mle7Gk1EI/DlTC6DR2PBeU7il07/t1QSriVmU+1pH+gmF4ZoFhWp04YJoCXMQ2cV1tFAsaiA5F0KMxVBcdzMEg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1095,9 +1092,6 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
-
-  '@std-uritemplate/std-uritemplate@1.0.5':
-    resolution: {integrity: sha512-3LHrjMZXHb0gRgSYTypFPew27Fd8t8l/3zSnQncetnNiLMkBF6P7Q7O+1otQqQDCK8dzAuh2C6lSb35H+xYizw==}
 
   '@std-uritemplate/std-uritemplate@2.0.1':
     resolution: {integrity: sha512-HC5kiXCa7Mxrv7SI7qH4ECfC1H+vFG15COBtX8aUur8EGEWK17RH3QVyBxtyjUXE448O4fGhQHh3kirEvPGWjw==}
@@ -2235,9 +2229,6 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
-
-  guid-typescript@1.0.9:
-    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -3651,10 +3642,6 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
-
   uuid@11.0.5:
     resolution: {integrity: sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==}
     hasBin: true
@@ -4651,15 +4638,6 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  '@microsoft/kiota-abstractions@1.0.0-preview.66':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@std-uritemplate/std-uritemplate': 1.0.5
-      guid-typescript: 1.0.9
-      tinyduration: 3.3.1
-      tslib: 2.7.0
-      uuid: 10.0.0
-
   '@microsoft/kiota-abstractions@1.0.0-preview.81':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -4668,28 +4646,24 @@ snapshots:
       tslib: 2.7.0
       uuid: 11.0.5
 
-  '@microsoft/kiota-serialization-form@1.0.0-preview.54':
+  '@microsoft/kiota-serialization-form@1.0.0-preview.81':
     dependencies:
       '@microsoft/kiota-abstractions': 1.0.0-preview.81
-      guid-typescript: 1.0.9
       tslib: 2.7.0
 
-  '@microsoft/kiota-serialization-json@1.0.0-preview.66':
+  '@microsoft/kiota-serialization-json@1.0.0-preview.81':
     dependencies:
       '@microsoft/kiota-abstractions': 1.0.0-preview.81
-      guid-typescript: 1.0.9
       tslib: 2.7.0
 
-  '@microsoft/kiota-serialization-multipart@1.0.0-preview.44':
+  '@microsoft/kiota-serialization-multipart@1.0.0-preview.81':
     dependencies:
       '@microsoft/kiota-abstractions': 1.0.0-preview.81
-      guid-typescript: 1.0.9
       tslib: 2.7.0
 
-  '@microsoft/kiota-serialization-text@1.0.0-preview.63':
+  '@microsoft/kiota-serialization-text@1.0.0-preview.81':
     dependencies:
       '@microsoft/kiota-abstractions': 1.0.0-preview.81
-      guid-typescript: 1.0.9
       tslib: 2.7.0
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4770,8 +4744,6 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
-
-  '@std-uritemplate/std-uritemplate@1.0.5': {}
 
   '@std-uritemplate/std-uritemplate@2.0.1': {}
 
@@ -6145,8 +6117,6 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
-
-  guid-typescript@1.0.9: {}
 
   has-bigints@1.0.2: {}
 
@@ -7784,8 +7754,6 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
-
-  uuid@10.0.0: {}
 
   uuid@11.0.5: {}
 


### PR DESCRIPTION
Add `repositoryUrl` to resources JSON schema of applications, plugins, examples, and templates.

The property is added for retrocompatibility and is marked as `deprecated`. To allow this I needed to define a custom JSON Schema 7 type accounting for `deprecated` property (this is allowed by JSON Schema specification, and `deprecated` is a well-known keyword of Monaco Editor) 