### PR TITLE
Support for marking labels for deployment selector

### DIFF
--- a/.changeset/shaggy-buttons-shave.md
+++ b/.changeset/shaggy-buttons-shave.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": minor
+---
+
+add support for marking labels as deployment selector

--- a/packages/console-types/src/types/services.test.ts
+++ b/packages/console-types/src/types/services.test.ts
@@ -19,6 +19,7 @@
 /* eslint-disable max-lines */
 import Ajv from 'ajv'
 import t from 'tap'
+import { FromSchema } from 'json-schema-to-ts'
 
 import {
   CoreService,
@@ -35,6 +36,8 @@ import {
   host,
   probesPath,
   service,
+  serviceLabel,
+  kubernetesDefinition,
   serviceSecretMountPath,
   serviceSecretName,
   swaggerPath,
@@ -202,6 +205,51 @@ t.test('services', t => {
       t.end()
     })
 
+    t.end()
+  })
+
+  t.test('labels and annotations', t => {
+    const sharedType: FromSchema<typeof kubernetesDefinition> = {
+      name: 'labelskey',
+      value: 'labelsvalye',
+    }
+
+    const newLabelType: FromSchema<typeof serviceLabel> = {
+      name: 'labelskey',
+      value: 'labelsvalue',
+      readOnly: false,
+      isSelector: true,
+    }
+
+    const service: CustomService = {
+      name: 'myservice',
+      type: ServiceTypes.CUSTOM,
+      advanced: false,
+      replicas: 1,
+      dockerImage: 'helloworld:1.0.0',
+      labels: [
+        newLabelType,
+        sharedType,
+      ],
+      annotations: [
+        sharedType,
+      ],
+      additionalContainers: [
+        {
+          name: 'container',
+          dockerImage: 'helloworld:1.0.0',
+          labels: [
+            sharedType,
+            newLabelType,
+          ],
+          annotations: [
+            sharedType,
+          ],
+        },
+      ],
+    }
+
+    t.ok(validate(service), validationMessage(validate.errors))
     t.end()
   })
 

--- a/packages/console-types/src/types/services.ts
+++ b/packages/console-types/src/types/services.ts
@@ -553,6 +553,19 @@ export const kubernetesDefinitionName = {
   [VALIDATION_ERROR_ID]: 'kubernetesDefinition.patternError',
 } as const
 
+export const serviceLabel = {
+  type: 'object',
+  properties: {
+    name: kubernetesDefinitionName,
+    value: { type: 'string' },
+    description,
+    readOnly: { type: 'boolean' },
+    isSelector: { type: 'boolean' },
+  },
+  additionalProperties: false,
+  required: ['name', 'value'],
+} as const
+
 export const kubernetesDefinition = {
   type: 'object',
   properties: {
@@ -580,7 +593,12 @@ export const container = {
     },
     labels: {
       type: 'array',
-      items: kubernetesDefinition,
+      items: {
+        anyOf: [
+          kubernetesDefinition,
+          serviceLabel,
+        ],
+      },
     },
     resources: serviceResources,
     probes,
@@ -934,7 +952,10 @@ export const services = {
   default: {},
 } as const
 
+// @Deprecated Use one of ServiceAnnotation or ServiceLabel
 export type LabelAnnotation = FromSchema<typeof kubernetesDefinition>
+export type ServiceAnnotation = FromSchema<typeof kubernetesDefinition>
+export type ServiceLabel = FromSchema<typeof serviceLabel>
 
 // This type is required since Services cannot parse if/then/else since it is too deep
 export type Services = Record<string,

--- a/packages/console-types/tap-snapshots/src/types/config.test.ts.test.cjs
+++ b/packages/console-types/tap-snapshots/src/types/config.test.ts.test.cjs
@@ -5822,28 +5822,59 @@ Object {
                     },
                     "labels": Object {
                       "items": Object {
-                        "additionalProperties": false,
-                        "properties": Object {
-                          "description": Object {
-                            "type": "string",
+                        "anyOf": Array [
+                          Object {
+                            "additionalProperties": false,
+                            "properties": Object {
+                              "description": Object {
+                                "type": "string",
+                              },
+                              "name": Object {
+                                "pattern": "^([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,253}[\\\\/])?([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,63}[a-zA-Z0-9]?)$",
+                                "type": "string",
+                                "x-validation-error-id": "kubernetesDefinition.patternError",
+                              },
+                              "readOnly": Object {
+                                "type": "boolean",
+                              },
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                            "required": Array [
+                              "name",
+                              "value",
+                            ],
+                            "type": "object",
                           },
-                          "name": Object {
-                            "pattern": "^([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,253}[\\\\/])?([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,63}[a-zA-Z0-9]?)$",
-                            "type": "string",
-                            "x-validation-error-id": "kubernetesDefinition.patternError",
+                          Object {
+                            "additionalProperties": false,
+                            "properties": Object {
+                              "description": Object {
+                                "type": "string",
+                              },
+                              "isSelector": Object {
+                                "type": "boolean",
+                              },
+                              "name": Object {
+                                "pattern": "^([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,253}[\\\\/])?([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,63}[a-zA-Z0-9]?)$",
+                                "type": "string",
+                                "x-validation-error-id": "kubernetesDefinition.patternError",
+                              },
+                              "readOnly": Object {
+                                "type": "boolean",
+                              },
+                              "value": Object {
+                                "type": "string",
+                              },
+                            },
+                            "required": Array [
+                              "name",
+                              "value",
+                            ],
+                            "type": "object",
                           },
-                          "readOnly": Object {
-                            "type": "boolean",
-                          },
-                          "value": Object {
-                            "type": "string",
-                          },
-                        },
-                        "required": Array [
-                          "name",
-                          "value",
                         ],
-                        "type": "object",
                       },
                       "type": "array",
                     },
@@ -6558,28 +6589,59 @@ Object {
               },
               "labels": Object {
                 "items": Object {
-                  "additionalProperties": false,
-                  "properties": Object {
-                    "description": Object {
-                      "type": "string",
+                  "anyOf": Array [
+                    Object {
+                      "additionalProperties": false,
+                      "properties": Object {
+                        "description": Object {
+                          "type": "string",
+                        },
+                        "name": Object {
+                          "pattern": "^([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,253}[\\\\/])?([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,63}[a-zA-Z0-9]?)$",
+                          "type": "string",
+                          "x-validation-error-id": "kubernetesDefinition.patternError",
+                        },
+                        "readOnly": Object {
+                          "type": "boolean",
+                        },
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "name",
+                        "value",
+                      ],
+                      "type": "object",
                     },
-                    "name": Object {
-                      "pattern": "^([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,253}[\\\\/])?([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,63}[a-zA-Z0-9]?)$",
-                      "type": "string",
-                      "x-validation-error-id": "kubernetesDefinition.patternError",
+                    Object {
+                      "additionalProperties": false,
+                      "properties": Object {
+                        "description": Object {
+                          "type": "string",
+                        },
+                        "isSelector": Object {
+                          "type": "boolean",
+                        },
+                        "name": Object {
+                          "pattern": "^([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,253}[\\\\/])?([a-zA-Z0-9][a-zA-Z0-9\\\\.\\\\-]{0,63}[a-zA-Z0-9]?)$",
+                          "type": "string",
+                          "x-validation-error-id": "kubernetesDefinition.patternError",
+                        },
+                        "readOnly": Object {
+                          "type": "boolean",
+                        },
+                        "value": Object {
+                          "type": "string",
+                        },
+                      },
+                      "required": Array [
+                        "name",
+                        "value",
+                      ],
+                      "type": "object",
                     },
-                    "readOnly": Object {
-                      "type": "boolean",
-                    },
-                    "value": Object {
-                      "type": "string",
-                    },
-                  },
-                  "required": Array [
-                    "name",
-                    "value",
                   ],
-                  "type": "object",
                 },
                 "type": "array",
               },


### PR DESCRIPTION
This PR is aimed to adding a new property, `isSelector` to the service labels that can be used for signalling that they are selected to be used as Deployment selector instead of generating it with a fixed one.

It will also mark the type `LabelAnnotation` as deprecated favouring the separated types `ServiceLabel` and `ServiceAnnotation`.
