### PR TITLE
Add missing export in index file for ServiceLabel and ServiceAnnotation

### DIFF
--- a/.changeset/tricky-bees-sin.md
+++ b/.changeset/tricky-bees-sin.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+add missing ServiceLabel and ServiceAnnotation export in index file

--- a/packages/console-types/src/index.ts
+++ b/packages/console-types/src/index.ts
@@ -226,6 +226,8 @@ export type {
   ContainerPorts,
   CoreService,
   CustomResource,
+  ServiceLabel,
+  ServiceAnnotation,
   LabelAnnotation,
 } from './types/services'
 


### PR DESCRIPTION
This PR will add a missing export in the index file for the `ServiceLabel` and `ServiceAnnotation` type.