### PR TITLE
feat(infrastructure components): add properties related to the pipeline webhook

### DIFF
--- a/.changeset/hungry-candles-obey.md
+++ b/.changeset/hungry-candles-obey.md
@@ -2,4 +2,4 @@
 "@mia-platform/console-types": patch
 ---
 
-feat(infrastructure components): add properties related to the pipeline webhook
+feat(infrastructure components): add properties related to the pipeline webhook and pipeline status

--- a/.changeset/hungry-candles-obey.md
+++ b/.changeset/hungry-candles-obey.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+feat(infrastructure components): add properties related to the pipeline webhook

--- a/packages/console-types/src/constants/provider.ts
+++ b/packages/console-types/src/constants/provider.ts
@@ -40,4 +40,5 @@ export const PIPELINE_STATUS = {
   RUNNING: 'running',
   PENDING: 'pending',
   LOADING: 'loading',
+  MANUAL: 'manual',
 }

--- a/packages/console-types/src/types/project.test.ts
+++ b/packages/console-types/src/types/project.test.ts
@@ -23,7 +23,6 @@ import t from 'tap'
 import { IEnvironment, IProject, branchName, environment, environments, project } from './project'
 import { PatternTest, createTestsRegex, validationMessage } from './validate-utils.test'
 import { PROJECT_APPLICATION_FLAVOR, PROMETHEUS_OPERATOR } from '../constants/project'
-import { PROJECT_INFRASTRUCTURE_FLAVOR } from '../../build/constants/project'
 
 export const fullEnvironment: Required<IEnvironment> = {
   type: 'runtime',
@@ -492,7 +491,7 @@ t.test('project validated', t => {
       projectId: 'my-project-id',
       repositoryUrl: 'repo-url',
       _id: 'object-id',
-      flavor: PROJECT_INFRASTRUCTURE_FLAVOR,
+      flavor: 'infrastructure',
       infrastructureComponents: {
         'component-1': {
           name: 'component-1',

--- a/packages/console-types/src/types/project.test.ts
+++ b/packages/console-types/src/types/project.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /**
  * Copyright 2024 Mia srl
  *
@@ -22,6 +23,7 @@ import t from 'tap'
 import { IEnvironment, IProject, branchName, environment, environments, project } from './project'
 import { PatternTest, createTestsRegex, validationMessage } from './validate-utils.test'
 import { PROJECT_APPLICATION_FLAVOR, PROMETHEUS_OPERATOR } from '../constants/project'
+import { PROJECT_INFRASTRUCTURE_FLAVOR } from '../../build/constants/project'
 
 export const fullEnvironment: Required<IEnvironment> = {
   type: 'runtime',
@@ -482,6 +484,78 @@ t.test('project validated', t => {
     t.end()
   })
 
+  t.test('infrastructure project', t => {
+    // Includes two components, one with webhook active and one without
+    const project: IProject = {
+      name: 'template-name',
+      configurationGitPath: 'config-path',
+      projectId: 'my-project-id',
+      repositoryUrl: 'repo-url',
+      _id: 'object-id',
+      flavor: PROJECT_INFRASTRUCTURE_FLAVOR,
+      infrastructureComponents: {
+        'component-1': {
+          name: 'component-1',
+          gitInfo: {
+            repoUrl: 'repo-url',
+          },
+          pipelineInfo: {
+            projectId: '120011',
+            refName: 'main',
+            isPipelineEventWebhookActive: true,
+            statusWebhookSecretCredentialsId: 'credential-id',
+          },
+        },
+        'component-2': {
+          name: 'component-2',
+          gitInfo: {
+            repoUrl: 'repo-url',
+          },
+          pipelineInfo: {
+            projectId: '120011',
+            refName: 'main',
+          },
+        },
+      },
+      originalTemplate: { id: 'templateid', name: 'template name' },
+      environments: [],
+      repository: {
+        providerId: 'provider-id',
+        provider: {
+          type: 'gitlab',
+          baseUrl: 'base-url',
+          apiBaseUrl: 'api-base-url',
+          accessToken: 'my-secret-access-token',
+          providerId: 'provider-id',
+        },
+      },
+      description: 'my description',
+      environmentsVariables: {
+        type: 'gitlab',
+        baseUrl: 'base-url',
+        storage: {
+          type: 'groups',
+          id: '123',
+        },
+      },
+      enabledServices: {},
+      pipelines: {
+        type: 'gitlab-ci',
+      },
+      tenantId: 'my-tenant',
+      color: '#666666',
+      info: {
+        projectOwner: 'the owner',
+        teamContact: 'the team contact',
+        technologies: ['node', 'golang'],
+      },
+      layerId: 'layer',
+    }
+
+    t.ok(validate(project), validationMessage(validate.errors))
+    t.end()
+  })
+
   t.end()
 })
 
@@ -520,4 +594,3 @@ t.test('branchName json schema pattern', t => {
 
   t.end()
 })
-

--- a/packages/console-types/src/types/project.ts
+++ b/packages/console-types/src/types/project.ts
@@ -515,7 +515,7 @@ export const infrastructureComponent = {
         },
         statusWebhookSecretCredentialsId: {
           type: 'string',
-          description: 'ID of the secret used to authenticate the webhook',
+          description: 'ID of the credential item that includes the secret used to authenticate the webhook',
         },
         jobs: {
           type: 'object',

--- a/packages/console-types/src/types/project.ts
+++ b/packages/console-types/src/types/project.ts
@@ -509,6 +509,14 @@ export const infrastructureComponent = {
           type: 'string',
           description: 'Name of the ref used to trigger the pipeline',
         },
+        isPipelineEventWebhookActive: {
+          type: 'boolean',
+          description: 'Whether the pipeline event webhook is enabled or not',
+        },
+        statusWebhookSecretCredentialsId: {
+          type: 'string',
+          description: 'ID of the secret used to authenticate the webhook',
+        },
         jobs: {
           type: 'object',
           properties: {


### PR DESCRIPTION
Includes:
- a flag to be set to true if a webhook URL should be called when the pipeline status of a infrastructure component is updated
- a credentialId, which is the identifier of the credentials stored to the database (that contains the provider token to be used as a safety check when the URL is called)