### PR TITLE
changes saveChangesRules field of project and tenant to support allow rules for fine-grain-access-control 

### DIFF
--- a/.changeset/dirty-dogs-exist.md
+++ b/.changeset/dirty-dogs-exist.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+add `allowedRuleSet` to project and tenant `saveChangesRules` field

--- a/.changeset/good-guests-tan.md
+++ b/.changeset/good-guests-tan.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+change type of `action` field in project and tenant `saveChangesRules` field

--- a/packages/console-types/src/types/project.test.ts
+++ b/packages/console-types/src/types/project.test.ts
@@ -412,6 +412,11 @@ t.test('project validated', t => {
             ruleId: 'somerule',
             processingOptions: { action: 'create', primaryKey: 'somekey' },
           }],
+          allowedRuleSet: [{
+            jsonPath: 'test1',
+            ruleId: 'somerule1',
+            processingOptions: { action: 'create', primaryKey: 'somekey1' },
+          }],
           roleIds: ['testrole'],
         }],
       },

--- a/packages/console-types/src/types/project.ts
+++ b/packages/console-types/src/types/project.ts
@@ -374,29 +374,37 @@ export const monitoring = {
   },
 } as const
 
+const ruleSet = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      jsonPath: { type: 'string' },
+      ruleId: { type: 'string' },
+      processingOptions: {
+        type: 'object',
+        properties: {
+          action: {
+            oneOf: [
+              { type: 'string', enum: ['create', 'delete'] },
+              { type: 'array', items: { type: 'string', enum: ['create', 'delete'] } }
+            ]
+          },
+          primaryKey: { type: 'string' },
+        },
+        required: ['action'],
+      },
+    },
+  },
+} as const
+
 export const saveChangesRules = {
   type: 'array',
   items: {
     type: 'object',
     properties: {
-      disallowedRuleSet: {
-        type: 'array',
-        items: {
-          type: 'object',
-          properties: {
-            jsonPath: { type: 'string' },
-            ruleId: { type: 'string' },
-            processingOptions: {
-              type: 'object',
-              properties: {
-                action: { type: 'string', enum: ['create', 'delete'] },
-                primaryKey: { type: 'string' },
-              },
-              required: ['action'],
-            },
-          },
-        },
-      },
+      disallowedRuleSet: ruleSet,
+      allowedRuleSet: ruleSet,
       roleIds: {
         type: 'array',
         items: { type: 'string' },

--- a/packages/console-types/src/types/tenant.test.ts
+++ b/packages/console-types/src/types/tenant.test.ts
@@ -84,6 +84,7 @@ t.test('tenants validated', t => {
         },
         saveChangesRules: [{
           disallowedRuleSet: [{ jsonPath: 'test' }],
+          allowedRuleSet: [{ jsonPath: 'test1' }],
           roleIds: ['testrole'],
         }],
       },


### PR DESCRIPTION
- add `allowedRuleSet` to project and tenant `saveChangesRules` field
- change type of `action` field in project and tenant `saveChangesRules` field