### PR TITLE
feat(IDP-2982) Replace boolean with webhook ID for pipeline event webhook

### DIFF
--- a/.changeset/calm-forks-check.md
+++ b/.changeset/calm-forks-check.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+replaced not used `isPipelineEventWebhookActive` property with `pipelineEventWebhookId`

--- a/.changeset/calm-forks-check.md
+++ b/.changeset/calm-forks-check.md
@@ -1,5 +1,5 @@
 ---
-"@mia-platform/console-types": patch
+"@mia-platform/console-types": minor
 ---
 
 replaced not used `isPipelineEventWebhookActive` property with `pipelineEventWebhookId`

--- a/packages/console-types/src/types/project.test.ts
+++ b/packages/console-types/src/types/project.test.ts
@@ -501,7 +501,7 @@ t.test('project validated', t => {
           pipelineInfo: {
             projectId: '120011',
             refName: 'main',
-            isPipelineEventWebhookActive: true,
+            pipelineEventWebhookId: "12345",
             statusWebhookSecretCredentialsId: 'credential-id',
           },
         },

--- a/packages/console-types/src/types/project.test.ts
+++ b/packages/console-types/src/types/project.test.ts
@@ -501,7 +501,7 @@ t.test('project validated', t => {
           pipelineInfo: {
             projectId: '120011',
             refName: 'main',
-            pipelineEventWebhookId: "12345",
+            pipelineEventWebhookId: '12345',
             statusWebhookSecretCredentialsId: 'credential-id',
           },
         },

--- a/packages/console-types/src/types/project.ts
+++ b/packages/console-types/src/types/project.ts
@@ -492,6 +492,7 @@ export const infrastructureComponent = {
     pipelineInfo: {
       type: 'object',
       required: ['projectId'],
+      additionalProperties: false,
       properties: {
         providerId: {
           type: 'string',
@@ -509,9 +510,9 @@ export const infrastructureComponent = {
           type: 'string',
           description: 'Name of the ref used to trigger the pipeline',
         },
-        isPipelineEventWebhookActive: {
-          type: 'boolean',
-          description: 'Whether the pipeline event webhook is enabled or not',
+        pipelineEventWebhookId: {
+          type: 'string',
+          description: 'ID of the pipeline event webhook configured in the git provider',
         },
         statusWebhookSecretCredentialsId: {
           type: 'string',


### PR DESCRIPTION
Replaces the `isPipelineEventWebhookActive` boolean property with `pipelineEventWebhookId` string to store the ID of the pipeline event webhook.
This allows identifying the specific webhook configured in the git provider.