### PR TITLE
Exports InfrastructureComponents type and schemas

### DIFF
--- a/.changeset/witty-dodos-camp.md
+++ b/.changeset/witty-dodos-camp.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+exported InfrastructureComponents type and schemas

--- a/packages/console-types/src/index.ts
+++ b/packages/console-types/src/index.ts
@@ -64,6 +64,8 @@ import {
   project,
   tagName,
   containerRegistry,
+  infrastructureComponent,
+  infrastructureComponents,
 } from './types/project'
 import {
   configMap,
@@ -211,6 +213,9 @@ export {
   containerRegistryHostnameString,
 
   providerCapabilitiesSchema,
+
+  infrastructureComponent,
+  infrastructureComponents,
 }
 
 export type {
@@ -257,6 +262,7 @@ export type {
   ProjectEnvironmentLink,
   AISettings,
   InfrastructureComponent,
+  InfrastructureComponents,
 } from './types/project'
 
 export {

--- a/packages/console-types/src/types/project.ts
+++ b/packages/console-types/src/types/project.ts
@@ -546,6 +546,7 @@ export const infrastructureComponents = {
     '^[a-z]([-_a-z0-9]*[a-z0-9])?$': infrastructureComponent,
   },
 } as const
+export type InfrastructureComponents = FromSchema<typeof infrastructureComponents>
 
 export const project = {
   type: 'object',


### PR DESCRIPTION
Exports the InfrastructureComponents type and its associated schemas, making them available for use in other modules.