### PR TITLE
fix: fix in infrastructureComponent schema to avoid usage of oneOf

### DIFF
--- a/.changeset/tall-dodos-rest.md
+++ b/.changeset/tall-dodos-rest.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+fix: fix in infrastructureComponent schema to avoid usage of oneOf

--- a/packages/console-types/src/types/project.ts
+++ b/packages/console-types/src/types/project.ts
@@ -499,99 +499,57 @@ export const infrastructureComponent = {
       },
     },
     pipelineInfo: {
-      oneOf: [
-        {
+      type: 'object',
+      required: ['refName'],
+      additionalProperties: false,
+      properties: {
+        providerType: {
+          type: 'string',
+          enum: [
+            DEPLOYMENT_TYPES.GITLAB_CI,
+            DEPLOYMENT_TYPES.GITHUB,
+            DEPLOYMENT_TYPES.AZURE_PIPELINES,
+            DEPLOYMENT_TYPES.JENKINS,
+            DEPLOYMENT_TYPES.WEBHOOK,
+          ],
+          description: 'Type of the provider',
+        },
+        providerId: {
+          type: 'string',
+          description: 'Provider identifier. To be used in case you want to override the main project provider',
+        },
+        organizationName: {
+          type: 'string',
+          description: 'Name of the organization in the Git provider that hosts the component. Required for Azure Pipelines and GitHub Actions',
+        },
+        projectId: {
+          type: 'string',
+          description: 'ID of the project in the git provider, used to call the provider API to handle the component deployment',
+        },
+        refName: {
+          type: 'string',
+          description: 'Name of the ref (branch/tag) used to trigger the pipeline and its jobs',
+        },
+        pipelineId: {
+          type: 'string',
+          description: 'ID of the pipeline configured in the git provider. Required for Azure Pipelines and GitHub Actions',
+        },
+        pipelineEventWebhookId: {
+          type: 'string',
+          description: 'ID of the pipeline event webhook configured in the git provider',
+        },
+        statusWebhookSecretCredentialsId: {
+          type: 'string',
+          description: 'ID of the credential item that includes the secret used to authenticate the webhook',
+        },
+        jobs: {
           type: 'object',
-          required: ['projectId', 'refName'],
-          additionalProperties: false,
           properties: {
-            providerType: {
-              type: 'string',
-              enum: [
-                DEPLOYMENT_TYPES.GITLAB_CI,
-                DEPLOYMENT_TYPES.GITHUB,
-                DEPLOYMENT_TYPES.WEBHOOK,
-                DEPLOYMENT_TYPES.JENKINS,
-              ],
-              description: 'Type of the provider',
-            },
-            providerId: {
-              type: 'string',
-              description: 'Provider identifier. To be used in case you want to override the main project provider',
-            },
-            projectId: {
-              type: 'string',
-              description: 'ID of the project in the git provider, used to call the provider API to handle the component deployment',
-            },
-            refName: {
-              type: 'string',
-              description: 'Name of the ref (branch/tag) used to trigger the pipeline and its jobs',
-            },
-            pipelineEventWebhookId: {
-              type: 'string',
-              description: 'ID of the pipeline event webhook configured in the git provider',
-            },
-            statusWebhookSecretCredentialsId: {
-              type: 'string',
-              description: 'ID of the credential item that includes the secret used to authenticate the webhook',
-            },
-            jobs: {
-              type: 'object',
-              properties: {
-                planJobName: { type: 'string' },
-                applyJobName: { type: 'string' },
-              },
-            },
+            planJobName: { type: 'string' },
+            applyJobName: { type: 'string' },
           },
         },
-        {
-          type: 'object',
-          required: ['providerType', 'organizationName', 'projectId', 'pipelineId', 'refName'],
-          additionalProperties: false,
-          properties: {
-            providerType: {
-              type: 'string',
-              const: DEPLOYMENT_TYPES.AZURE_PIPELINES,
-              description: 'Type of the provider',
-            },
-            providerId: {
-              type: 'string',
-              description: 'Provider identifier. To be used in case you want to override the main project provider',
-            },
-            organizationName: {
-              type: 'string',
-              description: 'Name of the organization in the Git provider that hosts the component. Required for Azure Pipelines and GitHub Actions',
-            },
-            projectId: {
-              type: 'string',
-              description: 'ID of the project in the git provider, used to call the provider API to handle the component deployment',
-            },
-            refName: {
-              type: 'string',
-              description: 'Name of the ref (branch/tag) used to trigger the pipeline and its jobs',
-            },
-            pipelineId: {
-              type: 'string',
-              description: 'ID of the pipeline configured in the git provider. Required for Azure Pipelines and GitHub Actions',
-            },
-            pipelineEventWebhookId: {
-              type: 'string',
-              description: 'ID of the pipeline event webhook configured in the git provider',
-            },
-            statusWebhookSecretCredentialsId: {
-              type: 'string',
-              description: 'ID of the credential item that includes the secret used to authenticate the webhook',
-            },
-            jobs: {
-              type: 'object',
-              properties: {
-                planJobName: { type: 'string' },
-                applyJobName: { type: 'string' },
-              },
-            },
-          },
-        },
-      ],
+      },
     },
   },
   required: ['name', 'gitInfo', 'pipelineInfo'],


### PR DESCRIPTION
We relax the rules in `project.infrastructureComponents.$.pipelineInfo` to avoid the usage of the `oneOf` keyword, to avoid issues with libraries that uses the generated JSON Schema to validate the payload when passed via API.