### PR TITLE
Adds default visibility to git providers

### DIFF
--- a/.changeset/sour-dolphins-buy.md
+++ b/.changeset/sour-dolphins-buy.md
@@ -1,0 +1,5 @@
+---
+"@mia-platform/console-types": patch
+---
+
+added `defaultVisibility` field to git provider schema

--- a/packages/console-types/src/types/provider.ts
+++ b/packages/console-types/src/types/provider.ts
@@ -70,6 +70,9 @@ const gitProviderCapabilitySchema = {
   properties: {
     name: { const: GIT_PROVIDER },
     functionalities: providerFunctionalitiesSchema,
+    defaultVisibility: {
+      type: 'string',
+    },
     repositoryPathTemplate: {
       type: 'string',
     },

--- a/packages/console-types/tap-snapshots/src/types/provider.test.ts.test.cjs
+++ b/packages/console-types/tap-snapshots/src/types/provider.test.ts.test.cjs
@@ -315,6 +315,9 @@ exports[`src/types/provider.test.ts TAP providers match schema > must match snap
                   }
                 }
               },
+              "defaultVisibility": {
+                "type": "string"
+              },
               "repositoryPathTemplate": {
                 "type": "string"
               }


### PR DESCRIPTION
Adds the `defaultVisibility` field to the git provider schema.
This allows configuration of the default visibility setting for git providers.
